### PR TITLE
Fix: 修复 iOS Swift API 锚点链接错误

### DIFF
--- a/core_products/real-time-voice-video/zh/ios-swift/client-sdk/api-reference/function-list.mdx
+++ b/core_products/real-time-voice-video/zh/ios-swift/client-sdk/api-reference/function-list.mdx
@@ -203,7 +203,7 @@ API 返回的错误码请参考：/real-time-video-android-java/client-sdk/error
 [setPlayStreamDecryptionKey:streamID:](./class.mdx#setplaystreamdecryptionkeystreamid-zegoexpressengine) | 设置拉流解密密钥。
 [setPlayStreamCrossAppInfo:streamID:](./class.mdx#setplaystreamcrossappinfostreamid-zegoexpressengine) | 设置跨 App 拉流信息。
 [takePlayStreamSnapshot:callback:](./class.mdx#takeplaystreamsnapshotcallback-zegoexpressengine) | 拉流画面截图。
-[setPlayVolume:audioEffectID:](./class.mdx#setplayvolumeaudioeffectid-zegoexpressengine) | 设置拉流音量。
+[setPlayVolume:audioEffectID:](./class.mdx#setplayvolumeaudioeffectid-zegoaudioeffectplayer) | 设置拉流音量。
 [setAllPlayStreamVolume:](./class.mdx#setallplaystreamvolume-zegoexpressengine) | 设置所有拉流音量。
 [setPlayStreamVideoType:streamID:](./class.mdx#setplaystreamvideotypestreamid-zegoexpressengine) | 设置播放视频流类型。
 [setPlayStreamBufferIntervalRange:min:max:](./class.mdx#setplaystreambufferintervalrangeminmax-zegoexpressengine) | 设置拉流播放缓存自适应调整的区间范围。
@@ -262,7 +262,7 @@ API 返回的错误码请参考：/real-time-video-android-java/client-sdk/error
 [manager:receiveRealTimeSequentialData:streamID](./class.mdx#managerreceiverealtimesequentialdatastreamid-zegorealtimesequentialdataeventhandler) | 收到实时有序数据回调
 [sendBroadcastMessage:roomID:callback:](./class.mdx#sendbroadcastmessageroomidcallback-zegoexpressengine) | 发送房间广播消息。
 [sendBarrageMessage:roomID:callback:](./class.mdx#sendbarragemessageroomidcallback-zegoexpressengine) | 发送房间弹幕消息。
-[sendCustomCommand:callback:](./class.mdx#sendcustomcommandcallback-zegoexpressengine) | 发送自定义信令。
+[sendCustomCommand:callback:](./class.mdx#sendcustomcommandcallback-zegorangescene) | 发送自定义信令。
 [sendTransparentMessage:roomID:callback:](./class.mdx#sendtransparentmessageroomidcallback-zegoexpressengine) | 发送透传消息。
 [onRecvRoomTransparentMessage:roomID:](./protocol.mdx#onrecvroomtransparentmessageroomid-zegoeventhandler) | 接收房间透传消息。
 [onIMRecvBroadcastMessage:roomID:](./protocol.mdx#onimrecvbroadcastmessageroomid-zegoeventhandler) | 接收房间广播消息通知。
@@ -324,29 +324,29 @@ API 返回的错误码请参考：/real-time-video-android-java/client-sdk/error
 [setVideoHandler:format:type:](./class.mdx#setvideohandlerformattype-zegomediaplayer) | 设置媒体播放器的视频数据回调。
 [setAudioHandler:](./class.mdx#setaudiohandler-zegomediaplayer) | 设置媒体播放器的音频数据回调。
 [setBlockDataHandler:blockSize:](./class.mdx#setblockdatahandlerblocksize-zegomediaplayer) | 设置媒体播放器的媒体资源块数据回调。
-[loadResource:audioEffectID:callback:](./class.mdx#loadresourceaudioeffectidcallback-zegomediaplayer) | 加载本地或者网络媒体资源。
+[loadResource:audioEffectID:callback:](./class.mdx#loadresourceaudioeffectidcallback-zegoaudioeffectplayer) | 加载本地或者网络媒体资源。
 [loadResourceWithPosition:startPosition:callback:](./class.mdx#loadresourcewithpositionstartpositioncallback-zegomediaplayer) | 加载本地或者网络媒体资源，并指定开始位置。
 [loadResourceFromMediaData:startPosition:callback:](./class.mdx#loadresourcefrommediadatastartpositioncallback-zegomediaplayer) | 加载二进制的音频媒体资源。
 [loadCopyrightedMusicResourceWithPosition:startPosition:callback:](./class.mdx#loadcopyrightedmusicresourcewithpositionstartpositioncallback-zegomediaplayer) | 加载版权音乐资源。
 [loadResourceWithConfig:callback:](./class.mdx#loadresourcewithconfigcallback-zegomediaplayer) | 加载本地或者网络媒体资源，带配置参数。
-[start:path:config:](./class.mdx#startpathconfig-zegomediaplayer) | 开始播放
+[start:path:config:](./class.mdx#startpathconfig-zegoaudioeffectplayer) | 开始播放
 [stop:](./class.mdx#stop-zegomediaplayer) | 停止播放
 [pause:](./class.mdx#pause-zegomediaplayer) | 暂停播放
 [resume:](./class.mdx#resume-zegomediaplayer) | 恢复播放
 [seekTo:](./class.mdx#seekto-zegomediaplayer) | 设置指定的播放进度
 [enableRepeat:](./class.mdx#enablerepeat-zegomediaplayer) | 是否重复播放
-[setPlaySpeed:audioEffectID:](./class.mdx#setplayspeedaudioeffectid-zegomediaplayer) | 设置播放倍速。
+[setPlaySpeed:audioEffectID:](./class.mdx#setplayspeedaudioeffectid-zegoaudioeffectplayer) | 设置播放倍速。
 [enableAux:](./class.mdx#enableaux-zegomediaplayer) | 是否将播放器的声音混入正在推的流中
 [muteLocal:](./class.mdx#mutelocal-zegomediaplayer) | 是否静默本地播放
 [setPlayerCanvas:](./class.mdx#setplayercanvas-zegomediaplayer) | 设置播放器播放视频的视图
-[setVolume:audioEffectID:](./class.mdx#setvolumeaudioeffectid-zegomediaplayer) | 设置播放器音量，会同时设置本地播放音量和推流音量
-[setPlayVolume:audioEffectID:](./class.mdx#setplayvolumeaudioeffectid-zegomediaplayer) | 设置播放器本地播放音量
-[setPublishVolume:audioEffectID:](./class.mdx#setpublishvolumeaudioeffectid-zegomediaplayer) | 设置播放器推流音量
+[setVolume:audioEffectID:](./class.mdx#setvolumeaudioeffectid-zegoaudioeffectplayer) | 设置播放器音量，会同时设置本地播放音量和推流音量
+[setPlayVolume:audioEffectID:](./class.mdx#setplayvolumeaudioeffectid-zegoaudioeffectplayer) | 设置播放器本地播放音量
+[setPublishVolume:audioEffectID:](./class.mdx#setpublishvolumeaudioeffectid-zegoaudioeffectplayer) | 设置播放器推流音量
 [setProgressInterval:](./class.mdx#setprogressinterval-zegomediaplayer) | 设置播放进度回调间隔
 [playVolume](./class.mdx#playvolume-zegomediaplayer) | 获取当前媒体播放器本地播放的音量，范围为 0 ~ 200，默认值为 60
 [publishVolume](./class.mdx#publishvolume-zegomediaplayer) | 获取当前媒体播放器推流的音量，范围为 0 ~ 200，默认值为 60
-[getTotalDuration](./class.mdx#gettotalduration-zegomediaplayer) | 获取媒体资源的总进度
-[getCurrentProgress:](./class.mdx#getcurrentprogress-zegomediaplayer) | 获取当前播放进度
+[getTotalDuration](./class.mdx#gettotalduration-zegoaudioeffectplayer) | 获取媒体资源的总进度
+[getCurrentProgress:](./class.mdx#getcurrentprogress-zegoaudioeffectplayer) | 获取当前播放进度
 [currentRenderingProgress](./class.mdx#currentrenderingprogress-zegomediaplayer) | 获取当前渲染进度
 [audioTrackCount](./class.mdx#audiotrackcount-zegomediaplayer) | 获取播放文件的音轨个数
 [setAudioTrackIndex:](./class.mdx#setaudiotrackindex-zegomediaplayer) | 设置播放文件的音轨
@@ -354,7 +354,7 @@ API 返回的错误码请参考：/real-time-video-android-java/client-sdk/error
 [setAudioTrackPublishIndex:](./class.mdx#setaudiotrackpublishindex-zegomediaplayer) | 设置媒体文件需要推流的音轨
 [enableVoiceChanger:param:audioChannel:](./class.mdx#enablevoicechangerparamaudiochannel-zegomediaplayer) | 开启变声，设置变声的具体参数。
 [currentState](./class.mdx#currentstate-zegomediaplayer) | 获取当前播放状态
-[getIndex](./class.mdx#getindex-zegomediaplayer) | 获取媒体播放器的序号
+[getIndex](./class.mdx#getindex-zegoaudioeffectplayer) | 获取媒体播放器的序号
 [takeSnapshot:](./class.mdx#takesnapshot-zegomediaplayer) | 对媒体播放器当前播放画面进行截图
 [enableAccurateSeek:config:](./class.mdx#enableaccurateseekconfig-zegomediaplayer) | 开启精准 seek 并设置相关属性
 [setNetWorkResourceMaxCache:size:](./class.mdx#setnetworkresourcemaxcachesize-zegomediaplayer) | 设置网络素材最大的缓存时长和缓存数据大小
@@ -365,7 +365,7 @@ API 返回的错误码请参考：/real-time-video-android-java/client-sdk/error
 [setActiveAudioChannel:](./class.mdx#setactiveaudiochannel-zegomediaplayer) | 设置播放声道。
 [clearView](./class.mdx#clearview-zegomediaplayer) | 清除播放控件播放结束后, 在控件上保留的最后一帧画面。
 [getMediaInfo](./class.mdx#getmediainfo-zegomediaplayer) | 获取媒体文件视频分辨率等媒体信息。
-[updatePosition:position:](./class.mdx#updatepositionposition-zegomediaplayer) | 更新媒体播放器(音频源)位置。
+[updatePosition:position:](./class.mdx#updatepositionposition-zegoaudioeffectplayer) | 更新媒体播放器(音频源)位置。
 [setHttpHeader:](./class.mdx#sethttpheader-zegomediaplayer) | 设置 http 头信息。
 [setPlayMediaStreamType:](./class.mdx#setplaymediastreamtype-zegomediaplayer) | 设置播放的媒体流类型。
 [enableLiveAudioEffect:mode:](./class.mdx#enableliveaudioeffectmode-zegomediaplayer) | 开启现场音效。


### PR DESCRIPTION
## 修改内容

修复 `real_time_video_ios_swift_zh` 实例中的断链问题。

### 修复项
- 修复 `function-list.mdx` 中 12 个 ParamField 锚点链接错误
- 主要问题：ZEGOMediaPlayer/ZEGOExpressEngine 类名混淆导致锚点指向错误

### 修改文件
- core_products/real-time-voice-video/zh/ios-swift/client-sdk/api-reference/function-list.mdx