### PR TITLE
[RTC] Add titleSize h3 to Tabs in CDN playing recording screenshot auth doc

### DIFF
--- a/core_products/real-time-voice-video/zh/ios-oc/live-streaming/cdn-stream-playing-recording-screenshot-authentication.mdx
+++ b/core_products/real-time-voice-video/zh/ios-oc/live-streaming/cdn-stream-playing-recording-screenshot-authentication.mdx
@@ -24,7 +24,7 @@ date: "2026-04-03"
 ## 生成鉴权 URL
 
 <Tabs>
-<Tab title="腾讯云">
+<Tab title="腾讯云" titleSize="h3">
 
 #### 拉流鉴权
 
@@ -182,7 +182,7 @@ http://example.com/screenshot/1.jpg?txSecret=a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6&tx
 </Steps>
 
 </Tab>
-<Tab title="网宿云">
+<Tab title="网宿云" titleSize="h3">
 
 #### 拉流鉴权
 
@@ -299,7 +299,7 @@ http://example.com/record/123.flv?wsSecret=235cec79bf9483439762ddfd491387e2&wsAB
 </Steps>
 
 </Tab>
-<Tab title="华为云">
+<Tab title="华为云" titleSize="h3">
 
 #### 拉流鉴权
 


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Add titleSize h3 to Tabs in CDN playing recording screenshot auth doc

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: workspace-writer
working-dir: /home/doc/code/docs_all_writer_ktv_tabs
-->
