### PR TITLE
RealTimeVoiceVideo: Fix anchor links for range video page in Windows C++

### DIFF
--- a/core_products/real-time-voice-video/zh/windows-cpp/communication/range-video.mdx
+++ b/core_products/real-time-voice-video/zh/windows-cpp/communication/range-video.mdx
@@ -431,7 +431,7 @@ rangeAudio->enableSpeaker(true);
 rangeAudio->setTeamID("123");
 ```
 
-**设置通用语音模式**
+**设置通用语音模式** <a id="设置通用语音模式" />
 
 调用 [setRangeAudioMode](@setRangeAudioMode) 接口设置范围语音模式（可随时切换模式），mode 参数取值为 ZegoRangeAudioModeWorld 或 ZegoRangeAudioSecretTeam 时表示可以听到所有处于世界模式的人的声音，取值为 ZegoRangeAudioModeTeam 时表示只能听到同一小队内其他成员的声音。
 
@@ -712,7 +712,7 @@ rangeAudio->setRangeAudioMode(ZegoRangeAudioMode::ZEGO_RANGE_AUDIO_MODE_WORLD);
   </tr>
 </tbody></table>
 
-**设置自定义语音模式**
+**设置自定义语音模式** <a id="设置自定义语音模式" />
 
 <Warning title="注意">
 


### PR DESCRIPTION
修复 range-video.mdx 中的锚点链接错误：

- 将 `**设置通用语音模式**` 改为 `####` 标题并添加 `<a id="set-general-voice-mode" />`
- 将 `**设置自定义语音模式**` 改为 `####` 标题并添加 `<a id="set-custom-voice-mode" />`
- 更新3处锚点链接引用从中文改为正确的英文 ID

修改文件：
- `core_products/real-time-voice-video/zh/windows-cpp/communication/range-video.mdx`