### PR TITLE
[RTC] Fix Chinese-English domain mixing links in real-time voice video docs

### DIFF
--- a/core_products/real-time-voice-video/zh/rn-js/communication/pre-call-detection.mdx
+++ b/core_products/real-time-voice-video/zh/rn-js/communication/pre-call-detection.mdx
@@ -241,7 +241,7 @@ mediaPlayer.start();
  * 播放器播放状态回调
  * @param mediaPlayer 回调的播放器实例
  * @param state 播放器状态
- * @param errorCode 错误码，详情请参考常见错误码文档 https://docs.zegocloud.com/article/308.html
+ * @param errorCode 错误码，详情请参考常见错误码文档 https://doc-zh.zego.im/article/308.html
  */
 mediaPlayerStateUpdate: (mediaPlayer: ZegoMediaPlayer, state: ZegoMediaPlayerState, errorCode: number) => void;
 ```


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix Chinese-English domain mixing links in real-time voice video docs

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: check-link-20260414
working-dir: /home/doc/code/docs_all_writer_check_link_20260414_151145
-->
