### PR TITLE
[RTC] Fix Chinese-English domain mixing links in RealTimeVoice documentation

### DIFF
--- a/core_products/real-time-voice/zh/u3d-cs/client-sdk/api-reference/interface.mdx
+++ b/core_products/real-time-voice/zh/u3d-cs/client-sdk/api-reference/interface.mdx
@@ -372,7 +372,7 @@ date: "2026-04-09"
   parent_type="class">
 | 名称 | 类型 | 描述 |
 | --- | --- | --- |
-| capabilityDetection | string | 检测结果，类型为json字符串。字段含义查看文档 https://docs.zegocloud.com/article/api?doc=Express_Video_SDK_API~javascript_web~interface~ZegoCapabilityDetection |
+| capabilityDetection | string | 检测结果，类型为json字符串。字段含义查看文档 https://doc-zh.zego.im/article/api?doc=Express_Video_SDK_API~javascript_web~interface~ZegoCapabilityDetection |
 </ParamField>
 
 ## IZegoMediaPlayerHandler


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix Chinese-English domain mixing links in RealTimeVoice documentation

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: cron:83a502cc-31c2-41e2-be0c-856a2a752caf
working-dir: /home/doc/code/docs_all_writer_check_link_20260415_220000
-->
