### PR TITLE
[RTC] Fix broken internal links and anchor links in Video Call (iOS Swift) documentation

### DIFF
--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/live-streaming-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-co-hosting.mdx
@@ -185,7 +185,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass RoomRequest and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/live-streaming-server/api-reference/overview) to pass RoomRequest and combine your server's room business logic to increase the reliability of your app.
 
 
 ```mermaid

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-co-hosting.mdx
@@ -185,7 +185,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequest and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass RoomRequest and combine your server's room business logic to increase the reliability of your app.
 
 
 ```mermaid

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-co-hosting.mdx
@@ -185,7 +185,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass RoomRequest and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequest and combine your server's room business logic to increase the reliability of your app.
 
 
 ```mermaid

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-pk-battles.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-pk-battles.mdx
@@ -60,7 +60,7 @@ Below is the structure and outline of the content in this doc:
 
 If you are planning to implement the "PK battles coordinated by the business server", ignore this section.
 
-Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#implementation) to achieve this.
+Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#14007) to achieve this.
 
 </Note>
 

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-pk-battles.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-pk-battles.mdx
@@ -60,7 +60,7 @@ Below is the structure and outline of the content in this doc:
 
 If you are planning to implement the "PK battles coordinated by the business server", ignore this section.
 
-Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#14007) to achieve this.
+Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](/live-streaming-server/api-reference/overview) to achieve this.
 
 </Note>
 

--- a/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-pk-battles.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/best-practice/implement-pk-battles.mdx
@@ -60,7 +60,7 @@ Below is the structure and outline of the content in this doc:
 
 If you are planning to implement the "PK battles coordinated by the business server", ignore this section.
 
-Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#14007) to achieve this.
+Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#implementation) to achieve this.
 
 </Note>
 

--- a/core_products/low-latency-live-streaming/en/android-java/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/client-sdk/api-reference/class.mdx
@@ -13737,7 +13737,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/android-java/client-sdk/api/class/zegoexpressengine.mdx
+++ b/core_products/low-latency-live-streaming/en/android-java/client-sdk/api/class/zegoexpressengine.mdx
@@ -6020,7 +6020,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/android-kotlin/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/android-kotlin/client-sdk/api-reference/class.mdx
@@ -13737,7 +13737,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-a-live-audio-room.mdx
@@ -320,7 +320,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request signals, you will be able to easily extend your business signals.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-video-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-co-hosting.mdx
@@ -154,7 +154,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 
 ```mermaid

--- a/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-co-hosting.mdx
@@ -154,7 +154,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 
 ```mermaid

--- a/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/flutter-dart/best-practice/implement-co-hosting.mdx
@@ -154,7 +154,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 
 ```mermaid

--- a/core_products/low-latency-live-streaming/en/ios-oc/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-oc/client-sdk/api-reference/class.mdx
@@ -10325,7 +10325,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/ios-oc/client-sdk/api/class/zegoexpressengine.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-oc/client-sdk/api/class/zegoexpressengine.mdx
@@ -6271,7 +6271,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -39,7 +39,7 @@ In a live audio room:
 
 ### How to manage speaker seats
 
-In addition to implementing the above logic, the live audio room also needs to manage speaker seats. The speaker seat management function can usually be implemented using the [room attribute](/zim-ios/guides/room/room-properties.mdx) feature of the ZIM SDK. 
+In addition to implementing the above logic, the live audio room also needs to manage speaker seats. The speaker seat management function can usually be implemented using the [room attribute](/zim-ios/guides/room/room-properties) feature of the ZIM SDK. 
 
 This feature allows app clients to set and synchronize custom room attributes in the room. Room attributes are stored on the ZEGOCLOUD server in a Key-Value manner, and the ZEGOCLOUD server handles write conflict arbitration and other issues to ensure data consistency. 
 
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-co-hosting.mdx
@@ -163,7 +163,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-co-hosting.mdx
@@ -163,7 +163,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/live-streaming-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-co-hosting.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-co-hosting.mdx
@@ -163,7 +163,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-pk-battles.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-pk-battles.mdx
@@ -58,7 +58,7 @@ Below is the structure and outline of the content in this doc:
 
 If you are planning to implement the "PK battles coordinated by the business server", ignore this section.
 
-Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#implementation) to achieve this.
+Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#14007) to achieve this.
 </Note>
 
 A similar approach to call invitation is used here to implement PK battle invitations:

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-pk-battles.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-pk-battles.mdx
@@ -58,7 +58,7 @@ Below is the structure and outline of the content in this doc:
 
 If you are planning to implement the "PK battles coordinated by the business server", ignore this section.
 
-Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#14007) to achieve this.
+Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#implementation) to achieve this.
 </Note>
 
 A similar approach to call invitation is used here to implement PK battle invitations:

--- a/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-pk-battles.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/best-practice/implement-pk-battles.mdx
@@ -58,7 +58,7 @@ Below is the structure and outline of the content in this doc:
 
 If you are planning to implement the "PK battles coordinated by the business server", ignore this section.
 
-Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](#14007) to achieve this.
+Additionally, if your server does not have a signaling channel to send notifications to the client, we recommend using the `Command message (signaling message)` of the ZIM server API [Send in-room messages](/live-streaming-server/api-reference/overview) to achieve this.
 </Note>
 
 A similar approach to call invitation is used here to implement PK battle invitations:

--- a/core_products/low-latency-live-streaming/en/ios-swift/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/ios-swift/client-sdk/api-reference/class.mdx
@@ -10325,7 +10325,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/linux-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/linux-cpp/client-sdk/api-reference/class.mdx
@@ -9844,7 +9844,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/macos-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/macos-cpp/client-sdk/api-reference/class.mdx
@@ -9844,7 +9844,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/macos-oc/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/macos-oc/client-sdk/api-reference/class.mdx
@@ -10325,7 +10325,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/macos-swift/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/macos-swift/client-sdk/api-reference/class.mdx
@@ -10325,7 +10325,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/u3d-cs/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/u3d-cs/client-sdk/api-reference/class.mdx
@@ -7851,7 +7851,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/low-latency-live-streaming/en/windows-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/low-latency-live-streaming/en/windows-cpp/client-sdk/api-reference/class.mdx
@@ -9844,7 +9844,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice-video/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-video-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice-video/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice-video/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice-video/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice-video/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-video-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-video-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice-video/en/android-java/best-practice/implement-call-invitation.mdx
+++ b/core_products/real-time-voice-video/en/android-java/best-practice/implement-call-invitation.mdx
@@ -9,7 +9,7 @@ This doc will introduce how to implement the call invitation feature in the call
 
 Before you begin, make sure you complete the following:
 
-- Complete SDK integration and basic calling functions by referring to [Quick start](../quick-start/quick-start.mdx).
+- Complete SDK integration and basic calling functions by referring to [Quick start](../quick-start/integrating-sdk).
 - Download the [demo](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_android/tree/master/best_practice) that comes with this doc.
 - Activate the **In-app Chat** service.
 ![https://doc-media.zego.im/sdk-doc/Pics/InappChat/ActivateZIMinConsole2.png](https://doc-media.zego.im/sdk-doc/Pics/InappChat/ActivateZIMinConsole2.png)
@@ -963,7 +963,7 @@ public void autoRejectCallInviteCauseBusy(String callID, String extendedData,ZIM
 ### Start the call
 
 After any callee accepts the call invitation, the caller will receive the callback notification via `onCallInvitationAccepted`,and other invited user will receive `onCallUserStateChanged` to sync call user states.
-You can refer to the implementation of the call page in [Quick start](../quick-start/quick-start.mdx), or you can directly refer to the demo's [sample code](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_android/blob/master/best_practice/app/src/main/java/com/zegocloud/demo/bestpractice/activity/CallInvitationActivity.java) included in this doc.
+You can refer to the implementation of the call page in [Quick start](../quick-start/integrating-sdk), or you can directly refer to the demo's [sample code](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_android/blob/master/best_practice/app/src/main/java/com/zegocloud/demo/bestpractice/activity/CallInvitationActivity.java) included in this doc.
 
 > In this demo, we use `callID` as the `roomID` for `zego_express_sdk`.
 > For information on `roomID`, refer to **Key concepts**.

--- a/core_products/real-time-voice-video/en/android-java/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/android-java/client-sdk/api-reference/class.mdx
@@ -13736,7 +13736,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/android-java/client-sdk/api/class/zegoexpressengine.mdx
+++ b/core_products/real-time-voice-video/en/android-java/client-sdk/api/class/zegoexpressengine.mdx
@@ -6019,7 +6019,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/android-kotlin/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/android-kotlin/client-sdk/api-reference/class.mdx
@@ -13736,7 +13736,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/cocos-creator-ts/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/cocos-creator-ts/client-sdk/api-reference/class.mdx
@@ -4564,7 +4564,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/cocos-creator-ts/introduction/product-feature-list.mdx
+++ b/core_products/real-time-voice-video/en/cocos-creator-ts/introduction/product-feature-list.mdx
@@ -68,7 +68,7 @@ articleID: 18849
 |-----|-----|-----|
 | [Common Video Configuration](/real-time-video-cocos-creator/video/common-video-configuration)  | During video calls or live streaming, customize settings for video capture and playback related configurations, such as video capture resolution, video encoding output resolution, video frame rate, bitrate, view mode, and mirror mode, etc. | <ul><li>Video call</li> <li>Live streaming scenario</li></ul> |
 | [Video Capture Rotation](/real-time-video-cocos-creator/video/video-capture-rotation)| For mobile, provides 4 capture rotation modes (fixed ratio mode, adaptive mode, alignment mode, and custom mode), simplifying the complex adaptation problems faced by developers when implementing multi-end rotation performance, such as camera angle, resolution, automatic rotation, statusbar position adaptation, etc.| - |
-| [Basic Beauty Effects](/real-time-video-cocos-creator/video/basic-beauty)  | When in video calls or live streaming, if you want to present a good skin condition to the other party, you can combine [AI Effects](/ai-effects-android-java/overview/overview) to achieve basic beauty effects. | <ul><li>Show live streaming</li> <li>Audio/video call</li></ul>  |
+| [Basic Beauty Effects](/real-time-video-cocos-creator/video/basic-beauty)  | When in video calls or live streaming, if you want to present a good skin condition to the other party, you can combine [AI Effects](/ai-effects-android-java/overview) to achieve basic beauty effects. | <ul><li>Show live streaming</li> <li>Audio/video call</li></ul>  |
 
 ### Advanced Features
 

--- a/core_products/real-time-voice-video/en/flutter-dart/best-practice/implement-call-invitation.mdx
+++ b/core_products/real-time-voice-video/en/flutter-dart/best-practice/implement-call-invitation.mdx
@@ -8,7 +8,7 @@ This doc will introduce how to implement the call invitation feature in the call
 
 Before you begin, make sure you complete the following:
 
-- Complete SDK integration and basic calling functions by referring to [Quick start](../quick-start/quick-start.mdx).
+- Complete SDK integration and basic calling functions by referring to [Quick start](../quick-start/integrating-sdk).
 - Download the [demo](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_flutter/tree/master/best_practices) that comes with this doc.
 - Activate the **In-app Chat** service.
 ![https://doc-media.zego.im/sdk-doc/Pics/InappChat/ActivateZIMinConsole2.png](https://doc-media.zego.im/sdk-doc/Pics/InappChat/ActivateZIMinConsole2.png)
@@ -891,7 +891,7 @@ class ZegoCallController {
 ### Start the call 
 
 After the callee accepts the call invitation, the caller will receive the callback notification via `onUserRequestStateChanged`, and both parties can start the call. 
-You can refer to the implementation of the call page in [Quick start](../quick-start/quick-start.mdx), or you can directly refer to the demo's [sample code](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_flutter/blob/master/best_practices/lib/pages/call/calling_page.dart) included in this doc.
+You can refer to the implementation of the call page in [Quick start](../quick-start/integrating-sdk), or you can directly refer to the demo's [sample code](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_flutter/blob/master/best_practices/lib/pages/call/calling_page.dart) included in this doc.
 
 > In this demo, we use `callID` as the `roomID` for `zego_express_sdk`.
 > For information on `roomID`, refer to **Key concepts**.

--- a/core_products/real-time-voice-video/en/ios-oc/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/ios-oc/client-sdk/api-reference/class.mdx
@@ -10324,7 +10324,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/ios-oc/client-sdk/api/class/zegoexpressengine.mdx
+++ b/core_products/real-time-voice-video/en/ios-oc/client-sdk/api/class/zegoexpressengine.mdx
@@ -6270,7 +6270,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-video-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-video-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-video-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -39,7 +39,7 @@ In a live audio room:
 
 ### How to manage speaker seats
 
-In addition to implementing the above logic, the live audio room also needs to manage speaker seats. The speaker seat management function can usually be implemented using the [room attribute](/zim-ios/guides/room/room-properties.mdx) feature of the ZIM SDK. 
+In addition to implementing the above logic, the live audio room also needs to manage speaker seats. The speaker seat management function can usually be implemented using the [room attribute](/zim-ios/guides/room/room-properties) feature of the ZIM SDK. 
 
 This feature allows app clients to set and synchronize custom room attributes in the room. Room attributes are stored on the ZEGOCLOUD server in a Key-Value manner, and the ZEGOCLOUD server handles write conflict arbitration and other issues to ensure data consistency. 
 
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-call-invitation.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/best-practice/implement-call-invitation.mdx
@@ -9,7 +9,7 @@ This doc will introduce how to implement the call invitation feature in the call
 
 Before you begin, make sure you complete the following:
 
-- Complete SDK integration and basic calling functions by referring to [Quick start](../quick-start/quick-start.mdx).
+- Complete SDK integration and basic calling functions by referring to [Quick start](../quick-start/integrating-sdk).
 - Download the [demo](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_ios/tree/master/best_practice) that comes with this doc.
 - Activate the **In-app Chat** service.
 
@@ -726,7 +726,7 @@ class CallService: NSObject, ZegoCallManagerDelegate {
 ### Start the call 
 
 After the callee accepts the call invitation, the caller will receive the callback notification via `onUserRequestStateChanged`, and both parties can start the call. 
-You can refer to the implementation of the call page in [Quick start](../quick-start/quick-start.mdx), or you can directly refer to the demo's [sample code](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_ios/blob/master/best_practice/ZegoCloudSDKDemo/ViewControllers/CallingViewController.swift) included in this doc.
+You can refer to the implementation of the call page in [Quick start](../quick-start/integrating-sdk), or you can directly refer to the demo's [sample code](https://github.com/ZEGOCLOUD/zegocloud_sdk_demo_ios/blob/master/best_practice/ZegoCloudSDKDemo/ViewControllers/CallingViewController.swift) included in this doc.
 
 > In this demo, we use `callID` as the `roomID` for `zego_express_sdk`.
 > For information on `roomID`, refer to **Key concepts**.

--- a/core_products/real-time-voice-video/en/ios-swift/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/client-sdk/api-reference/class.mdx
@@ -10324,7 +10324,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/ios-swift/client-sdk/release-notes.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/client-sdk/release-notes.mdx
@@ -9,5 +9,5 @@ articleID: 12539
 <Warning title="Warning">
 
 
-Since the iOS-Swift platform and iOS-Objective-C platform share the same set of SDK interfaces, please refer to the iOS-Objective-C platform's [Release Notes](/real-time-video-ios-oc/client-sdk/release-notes.mdx) for the release notes of the iOS-Swift platform.
+Since the iOS-Swift platform and iOS-Objective-C platform share the same set of SDK interfaces, please refer to the iOS-Objective-C platform's [Release Notes](/real-time-video-ios-oc/client-sdk/release-notes) for the release notes of the iOS-Swift platform.
 </Warning>

--- a/core_products/real-time-voice-video/en/ios-swift/introduction/product-feature-list.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/introduction/product-feature-list.mdx
@@ -86,7 +86,7 @@ date: "2024-02-05"
 | Common Video Configurations  | During video calls or live streaming, customize the settings for capturing and playing video, such as video capture resolution, video encoding output resolution, video frame rate, bitrate, view mode, and mirror mode, etc. | <ul><li>Video call</li> <li>Live streaming scenarios</li></ul> |
 | Video Capture Rotation | For mobile devices, 4 capture rotation modes are provided (fixed ratio mode, adaptive mode, alignment mode, and custom mode), simplifying the complex adaptation problems faced by developers when implementing multi-end rotation performance, such as camera angle, resolution, auto-rotation, statusbar position adaptation, etc.| - |
 | Screen Sharing | Share screen content with other users in the Room in the form of video during video calls or interactive live streaming.| <ul><li>Video conference</li> <li>Gaming live streaming</li></ul>  |
-| Basic Face Beautification  | When conducting video calls or live streaming, if you want to present a good skin condition to the other party, you can combine [AI Effects](/ai-effects-android-java/overview/overview) to achieve basic face beautification functions. | <ul><li>Showcase live streaming</li> <li>Audio and video calls</li></ul>  |
+| Basic Face Beautification  | When conducting video calls or live streaming, if you want to present a good skin condition to the other party, you can combine [AI Effects](/ai-effects-android-java/overview) to achieve basic face beautification functions. | <ul><li>Showcase live streaming</li> <li>Audio and video calls</li></ul>  |
 | Watermark and Screenshot  | You can add watermarks such as copyright logos to the video screen.| Video sharing with copyrights, etc. |
 
 ### Advanced Features

--- a/core_products/real-time-voice-video/en/ios-swift/quick-start/implementing-video-call.mdx
+++ b/core_products/real-time-voice-video/en/ios-swift/quick-start/implementing-video-call.mdx
@@ -78,7 +78,7 @@ Choose either of the following methods to integrate the Video Call SDK into your
     <Warning title="Warning">Since version v3.2.0, the Pod name of the Video Call SDK is changed from `ZegoExpressEngine/Video` to `ZegoExpressEngine`; the Pod name of the Voice Call SDK is changed from `ZegoExpressEngine/Audio` to `ZegoExpressAudio`.</Warning>
 
 
-4. Execute `pod repo update` to update the local index to make sure the latest version of SDK can be installed. For the latest version number, see [ZEGOCLOUD Express-Video iOS SDK Release History](/real-time-voice-video-ios-swift/quick-start/release-notes).
+4. Execute `pod repo update` to update the local index to make sure the latest version of SDK can be installed. For the latest version number, see [ZEGOCLOUD Express-Video iOS SDK Release History](/real-time-video-ios-swift/client-sdk/release-notes).
 
 5. Execute `pod install` to install the SDK.
 
@@ -87,7 +87,7 @@ Choose either of the following methods to integrate the Video Call SDK into your
 <Accordion title="Import the SDK manually" defaultOpen="false">
     
 
-1. Download the latest version of SDK from [SDK downloads](/real-time-voice-video-ios-swift/quick-start/download-sdk). We recommend you use XCFramework, and then extract files from the downloaded SDK package.
+1. Download the latest version of SDK from [SDK downloads](/real-time-video-ios-swift/client-sdk/download-sdk). We recommend you use XCFramework, and then extract files from the downloaded SDK package.
 
 2. Copy the SDK dynamic library file `ZegoExpressEngine.xcframework` to the project directory.
 

--- a/core_products/real-time-voice-video/en/linux-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/linux-cpp/client-sdk/api-reference/class.mdx
@@ -9843,7 +9843,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/linux-cpp/introduction/product-feature-list.mdx
+++ b/core_products/real-time-voice-video/en/linux-cpp/introduction/product-feature-list.mdx
@@ -79,7 +79,7 @@ date: "2024-02-05"
 |-----|-----|-----|
 | [Common Video Configuration](/real-time-video-linux-cpp/video/common-video-configuration)  | During video calls or live streaming, customize settings related to captured and played video, such as video capture resolution, video encoding output resolution, video frame rate, bitrate, view mode, and mirror mode, etc. | <ul><li>Video call</li> <li>Live streaming scenarios</li></ul> |
 | [Set Video Attributes](/real-time-video-linux-cpp/video/video-attributes)| Set video attributes as needed to adjust the clarity, smoothness, and mirroring of the video screen to achieve a better user experience. | Video call |
-| Basic Beauty Effects  | When in video calls or live streaming, if you want to present good skin condition to the other party, you can combine with [AI Effects](/ai-effects-android-java/overview/overview) to implement basic beauty effects. | <ul><li>Showcase live streaming</li> <li>Audio/video call</li></ul>  |
+| Basic Beauty Effects  | When in video calls or live streaming, if you want to present good skin condition to the other party, you can combine with [AI Effects](/ai-effects-android-java/overview) to implement basic beauty effects. | <ul><li>Showcase live streaming</li> <li>Audio/video call</li></ul>  |
 
 ### Advanced Functions
 

--- a/core_products/real-time-voice-video/en/macos-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/macos-cpp/client-sdk/api-reference/class.mdx
@@ -9843,7 +9843,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/macos-oc/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/macos-oc/client-sdk/api-reference/class.mdx
@@ -10324,7 +10324,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/macos-swift/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/macos-swift/client-sdk/api-reference/class.mdx
@@ -10324,7 +10324,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/rn-js/introduction/product-feature-list.mdx
+++ b/core_products/real-time-voice-video/en/rn-js/introduction/product-feature-list.mdx
@@ -63,7 +63,7 @@ date: "2024-02-05"
 | [Common Video Configuration](/real-time-video-rn/video/common-video-configuration)  | During video calls or live streaming, customize settings for capturing and playing video-related configurations, such as video capture resolution, video encoding output resolution, video frame rate, bitrate, view mode, and mirror mode, etc. | <ul><li>Video call</li> <li>Live streaming scenario</li></ul> |
 | [Video Capture Rotation](/real-time-video-rn/video/video-capture-rotation) | When users use mobile devices for live streaming or video calls, they can adopt different video capture directions, and can adapt and adjust according to the angle of the peer user's camera direction. | Video calls and live streaming scenarios with multiple device types, scenarios requiring the best video playback angle |
 | [Screen Sharing](/real-time-video-rn/video/screen-sharing)    | Share screen content with other users in the room as video during video calls or interactive live streaming.| <ul><li>Video conference</li> <li>Gaming live streaming</li></ul>  |
-| Basic Beauty Effects  | When conducting video calls or live streaming, if you want to present a good skin condition to the other party, you can combine [AI Effects](/ai-effects-android-java/overview/overview) to achieve basic beauty effects. | <ul><li>Talent show live streaming</li> <li>Audio and video call</li></ul>  |
+| Basic Beauty Effects  | When conducting video calls or live streaming, if you want to present a good skin condition to the other party, you can combine [AI Effects](/ai-effects-android-java/overview) to achieve basic beauty effects. | <ul><li>Talent show live streaming</li> <li>Audio and video call</li></ul>  |
 
 ### Advanced Features
 

--- a/core_products/real-time-voice-video/en/u3d-cs/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/u3d-cs/client-sdk/api-reference/class.mdx
@@ -7850,7 +7850,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice-video/en/web/introduction/product-feature-list.mdx
+++ b/core_products/real-time-voice-video/en/web/introduction/product-feature-list.mdx
@@ -80,7 +80,7 @@ date: "2024-02-05"
 |-----|-----|-----|
 | [Common video configuration](/real-time-video-web/video/common-video-configuration)  | During video calls or live streaming, customize and set relevant configurations for Capture and playback video, such as video Capture resolution, video encoding output resolution, video frame rate, bitrate, View mode, and Mirror mode, etc. | <ul><li>Video Call</li> <li>Live streaming scenarios</li></ul> |
 | [Screen sharing](/real-time-video-web/video/screen-sharing)    | Share screen content with other users in the Room as video during Video Call or interactive live streaming.| <ul><li>Video conference</li> <li>Gaming live streaming</li></ul>  |
-| [Basic beauty effects](/real-time-video-web/video/basic-beauty)  | When in a Video Call or live streaming, if you want to present a good skin condition to the other party, you can combine [AI beauty effects](/ai-effects-android-java/overview/overview) to achieve basic beauty effect functionality. | <ul><li>Show live streaming</li> <li>Video Call</li></ul>  |
+| [Basic beauty effects](/real-time-video-web/video/basic-beauty)  | When in a Video Call or live streaming, if you want to present a good skin condition to the other party, you can combine [AI beauty effects](/ai-effects-android-java/overview) to achieve basic beauty effect functionality. | <ul><li>Show live streaming</li> <li>Video Call</li></ul>  |
 
 ### Advanced Features
 

--- a/core_products/real-time-voice-video/en/windows-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice-video/en/windows-cpp/client-sdk/api-reference/class.mdx
@@ -9843,7 +9843,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-voice-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-voice-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-voice-server/api-reference/overview) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice/en/android-java/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/android-java/best-practice/implement-a-live-audio-room.mdx
@@ -300,7 +300,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request RoomRequests, you will be able to easily extend your business RoomRequests.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass RoomRequests and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice/en/android-java/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/android-java/client-sdk/api-reference/class.mdx
@@ -13811,7 +13811,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/android-kotlin/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/android-kotlin/client-sdk/api-reference/class.mdx
@@ -13811,7 +13811,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/cocos-creator-ts/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/cocos-creator-ts/client-sdk/api-reference/class.mdx
@@ -4603,7 +4603,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/flutter-dart/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/flutter-dart/best-practice/implement-a-live-audio-room.mdx
@@ -320,7 +320,7 @@ Based on this pattern, when you need to do any protocol extensions in your busin
 After reading the following text and further understanding the implementation of seat-taking request signals, you will be able to easily extend your business signals.
 
 <Note title="Note">
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-video-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-voice-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 ```mermaid
 
 sequenceDiagram

--- a/core_products/real-time-voice/en/ios-oc/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/ios-oc/client-sdk/api-reference/class.mdx
@@ -10391,7 +10391,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-voice-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](/real-time-voice-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/real-time-voice/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](https://www.zegocloud.com/docs/real-time-voice-server/api-reference/overview) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/real-time-voice/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
+++ b/core_products/real-time-voice/en/ios-swift/best-practice/implement-a-live-audio-room.mdx
@@ -39,7 +39,7 @@ In a live audio room:
 
 ### How to manage speaker seats
 
-In addition to implementing the above logic, the live audio room also needs to manage speaker seats. The speaker seat management function can usually be implemented using the [room attribute](/zim-ios/guides/room/room-properties.mdx) feature of the ZIM SDK. 
+In addition to implementing the above logic, the live audio room also needs to manage speaker seats. The speaker seat management function can usually be implemented using the [room attribute](/zim-ios/guides/room/room-properties) feature of the ZIM SDK. 
 
 This feature allows app clients to set and synchronize custom room attributes in the room. Room attributes are stored on the ZEGOCLOUD server in a Key-Value manner, and the ZEGOCLOUD server handles write conflict arbitration and other issues to ensure data consistency. 
 
@@ -310,7 +310,7 @@ After reading the following text and further understanding the implementation of
 
 <Note title="Note">
 
-The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#14007) to pass signals and combine your server's room business logic to increase the reliability of your app.
+The demo in this document is a pure client API + ZEGOCLOUD solution. If you have your own business server and want to do more logical extensions, you can use our [Server API](#implementation) to pass signals and combine your server's room business logic to increase the reliability of your app.
 
 ```mermaid
 sequenceDiagram

--- a/core_products/real-time-voice/en/ios-swift/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/ios-swift/client-sdk/api-reference/class.mdx
@@ -10391,7 +10391,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/linux-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/linux-cpp/client-sdk/api-reference/class.mdx
@@ -9904,7 +9904,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/macos-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/macos-cpp/client-sdk/api-reference/class.mdx
@@ -9904,7 +9904,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/macos-oc/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/macos-oc/client-sdk/api-reference/class.mdx
@@ -10391,7 +10391,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/macos-swift/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/macos-swift/client-sdk/api-reference/class.mdx
@@ -10391,7 +10391,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/u3d-cs/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/u3d-cs/client-sdk/api-reference/class.mdx
@@ -7861,7 +7861,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/core_products/real-time-voice/en/windows-cpp/client-sdk/api-reference/class.mdx
+++ b/core_products/real-time-voice/en/windows-cpp/client-sdk/api-reference/class.mdx
@@ -9904,7 +9904,7 @@ Enable the Effects beauty environment. The SDK uses the specified video frame da
 - **Default value**: When this function is not called, the beauty environment is not activated by default.
 - **When to call**: Must be called before calling [startPreview], [startPublishingStream]. If you need to modify the configuration, please call [logoutRoom] to log out of the room first, otherwise it will not take effect.
 - **Related APIs**: [enableEffectsBeauty] switch beauty, [setEffectsBeautyParam] set beauty parameters.
-- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview/overview](/ai-effects-android-java/overview/overview) for best results.
+- **Caution**: This beauty function is the basic function. If it does not meet the expectations of the developer, you can use the custom video pre-processing function [enableCustomVideoProcessing] or the custom video capture function [enableCustomVideoCapture] docking and constructing the AI ​​Effects SDK [ZegoEffects] [/ai-effects-android-java/overview](/ai-effects-android-java/overview) for best results.
 </Note>
 
 <Warning title="">

--- a/general/en/faq/zego-solutions.mdx
+++ b/general/en/faq/zego-solutions.mdx
@@ -72,7 +72,7 @@ For details, please refer to the overview of each product:
 <td>ZEGO's real-time speech-to-text and translation service provided in partnership with intelligent voice industry ecosystem service providers. After SDK integration, it provides services to recognize audio streams in real-time as text and translate them into target languages, achieving barrier-free communication effects such as "output text while speaking". Real-time translation supports multiple mainstream languages such as Chinese, English, Japanese, Korean, French, and Spanish, and is suitable for scenarios such as real-time meeting transcription, live subtitles, cross-border communication, recording quality inspection, and audio content analysis.</td>
 </tr>
 <tr>
-<td><a target="_blank" href="/ai-effects-android-java/overview/overview">AI Effects</a></td>
+<td><a target="_blank" href="/ai-effects-android-java/overview">AI Effects</a></td>
 <td>Provides multiple intelligent image rendering algorithms, including intelligent beauty, face detection, and image segmentation.</td>
 </tr>
 <tr>


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix broken internal links and anchor links in Video Call (iOS Swift) documentation

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: cron:83a502cc-31c2-41e2-be0c-856a2a752caf
working-dir: /home/doc/code/docs_all_writer_check_link_20260415_230000
-->
