### PR TITLE
[AIAgent] Clarify client vs server callback support for status events, add create/delete callback examples

### DIFF
--- a/core_products/aiagent/zh/server/guides/display-user-and-agent-status.mdx
+++ b/core_products/aiagent/zh/server/guides/display-user-and-agent-status.mdx
@@ -5,11 +5,15 @@ date: '2026-02-05'
 
 在与智能体进行实时语音通话时，可能需要在客户端界面上实时展示智能体实例状态和用户说话的状态变化以提升用户体验。您可以通过监听服务端或客户端回调的相应事件来获取这些状态。
 
-状态消息包括以下类型：
+状态消息包括以下三类事件：
 
-- 智能体实例创建及销毁状态：智能体实例创建成功、智能体实例销毁成功。
-- 智能体实例状态事件：空闲中、倾听中、思考中、说话中。
-- 用户说话状态事件：开始说话，说话结束。
+| 事件类型 | 说明 | 客户端 RTC 回调 | 服务端回调 |
+|----------|------|-----------------|----------|
+| 智能体实例创建及销毁状态 | 智能体实例创建成功、智能体实例销毁成功 | 不支持 | ✅ 支持 |
+| 智能体实例状态事件 | 空闲中、倾听中、思考中、说话中 | ✅ 支持 | ✅ 支持 |
+| 用户说话状态事件 | 开始说话、说话结束 | ✅ 支持 | ✅ 支持 |
+
+<Note title="说明">智能体实例创建及销毁事件**仅通过服务端回调**通知，不会发送到客户端。如果您需要在客户端 UI 上展示智能体是否已准备好（对应创建成功和销毁），请通过服务端接收回调后，经由自有信令通道转发给客户端。</Note>
 
 ## 快速实现
 
@@ -364,36 +368,76 @@ zg.callExperimentalAPI({ method: "onRecvRoomChannelMessage", params: {} });
 回调内容示例如下：
 
 <CodeGroup>
-```json title="智能体实例状态回调" {5,7}
+```json title="智能体实例创建成功回调" {6}
 {
     "AppId": 1234567,
     "AgentInstanceId": "1912124734317838336",
+    "AgentUserId": "agent_user_1",
+    "RoomId": "room_1",
+    "Sequence": 1234567890,
     "Data": {
-        "Status": "LISTENING",// IDLE: 空闲 LISTENING: 正在听 THINKING: 正在想 SPEAKING: 正在做
+        "CreatedTimestamp": 1745502312982
+    },
+    "Event": "AgentInstanceCreated",
+    "Nonce": "7450395512627324902",
+    "Signature": "fd9c1ce54e85bd92f48b0a805e82a52b0c0c6445",
+    "Timestamp": 1745502313000
+}
+```
+```json title="智能体实例删除成功回调" {6-8}
+{
+    "AppId": 1234567,
+    "AgentInstanceId": "1912124734317838336",
+    "AgentUserId": "agent_user_1",
+    "RoomId": "room_1",
+    "Sequence": 1234567890,
+    "Data": {
+        "Code": 0,
+        "DeletedTimestamp": 1745502345138,
+        "LatencyData": {
+            "LLMTTFT": 613,
+            "LLMTPS": 11.493,
+            "TTSAudioFirstFrameTime": 783,
+            "TotalCost": 1693
+        }
+    },
+    "Event": "AgentInstanceDeleted",
+    "Nonce": "7450395512627324902",
+    "Signature": "fd9c1ce54e85bd92f48b0a805e82a52b0c0c6445",
+    "Timestamp": 1745502313000
+}
+```
+```json title="智能体实例状态回调" {6}
+{
+    "AppId": 1234567,
+    "AgentInstanceId": "1912124734317838336",
+    "AgentUserId": "agent_user_1",
+    "RoomId": "room_1",
+    "Sequence": 1234567890,
+    "Data": {
+        "Status": "LISTENING"
     },
     "Event": "AgentInstanceStatus",
     "Nonce": "7450395512627324902",
     "Signature": "fd9c1ce54e85bd92f48b0a805e82a52b0c0c6445",
-    "Timestamp": 1745502313000,
-    "AgentUserId": "123456789",
-    "RoomId": "123456789",
-    "Sequence": 123456789,
+    "Timestamp": 1745502313000
 }
 ```
-```json title="用户说话状态回调" {5,7}
+```json title="用户说话状态回调" {6}
 {
     "AppId": 1234567,
     "AgentInstanceId": "1912124734317838336",
+    "AgentUserId": "agent_user_1",
+    "RoomId": "room_1",
+    "Sequence": 1234567890,
     "Data": {
-        "Action": "SPEAK_BEGIN",// SPEAK_BEGIN: 开始说话 SPEAK_END: 说话结束
+        "UserId": "user_1",
+        "Action": "SPEAK_BEGIN"
     },
     "Event": "UserSpeakAction",
     "Nonce": "7450395512627324902",
     "Signature": "fd9c1ce54e85bd92f48b0a805e82a52b0c0c6445",
-    "Timestamp": 1745502313000,
-    "AgentUserId": "123456789",
-    "RoomId": "123456789",
-    "Sequence": 123456789,
+    "Timestamp": 1745502313000
 }
 ```
 </CodeGroup>


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [x] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Clarify client vs server callback support for status events, add create/delete callback examples

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: zego-Precision-3650-Tower-3147415
working-dir: /home/doc/code/docs_all_writer_agent_status_display
-->
