### PR TITLE
[ZIM] Fix broken anchor links in Unity 3D documentation: login1-zim and callback anchors

### DIFF
--- a/core_products/zim/zh/docs_zim_u3d_zh/Client SDKs/api-reference/function-list.mdx
+++ b/core_products/zim/zh/docs_zim_u3d_zh/Client SDKs/api-reference/function-list.mdx
@@ -36,7 +36,7 @@ API 返回的错误码，请参考 https://doc-zh.zego.im/article/11606。
 [GetInstance](./class.mdx#getinstance-zim) | 获取 ZIM 单例对象。
 [SetLogConfig](./class.mdx#setlogconfig-zim) | 设置日志相关配置。
 [SetCacheConfig](./class.mdx#setcacheconfig-zim) | 设置缓存相关配置。
-[Login](./class.mdx#login1-zim) | 登录，在使用所有功能之前必须先登录。
+[Login](./class.mdx#login-zim) | 登录，在使用所有功能之前必须先登录。
 [Login](./class.mdx#login-zim) | 登录，在使用所有功能之前必须先登录。
 [RenewToken](./class.mdx#renewtoken-zim) | 更新鉴权 Token。
 [QueryUsersInfo](./class.mdx#queryusersinfo-zim) | 查询用户信息。

--- a/core_products/zim/zh/docs_zim_u3d_zh/Guides/Room/Manage rooms.mdx
+++ b/core_products/zim/zh/docs_zim_u3d_zh/Guides/Room/Manage rooms.mdx
@@ -139,7 +139,7 @@ ZIM.GetInstance().OnRoomMemberJoined = (ZIM zim, List<ZIMUserInfo> memberList,
 
 <Frame width="512" height="auto" caption=""><img src="https://doc-media.zego.im/sdk-doc/Pics/ZIM/Unity/EnterRoom3_new.jpg" /></Frame>
 
-1. 注册 [OnRoomMemberJoined](@OnRoomMemberJoined)、[OnRoomMemberLeft](@OnRoomMemberLeft) 和 [OnRoomStateChanged](@OnRoomStateChanged) 回调，详情请参考 <a href="#callback">创建房间、加入房间 - 1. 注册回调</a>。
+1. 注册 [OnRoomMemberJoined](@OnRoomMemberJoined)、[OnRoomMemberLeft](@OnRoomMemberLeft) 和 [OnRoomStateChanged](@OnRoomStateChanged) 回调，详情请参考 <a href="#1-注册回调">创建房间、加入房间 - 1. 注册回调</a>。
 2. 客户端 X 登录后，调用 [EnterRoom](@EnterRoom) 接口，传入 [ZIMRoomInfo](@-ZIMRoomInfo) 信息，进入房间；如果传入的 roomID 不存在，将会自动创建一个房间并进入该房间。
 3. 客户端 Y 登录后，调用 [EnterRoom](@EnterRoom) 接口，传入由 X 创建的房间 roomID，直接进入房间。
 4. 进入房间成功后会收到 [OnRoomStateChanged](@OnRoomStateChanged) 的通知回调，[ZIMRoomState](@-ZIMRoomState) 为 Connected，[ZIMRoomEvent](@-ZIMRoomEvent) 为 Success。


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix broken anchor links in Unity 3D documentation: login1-zim and callback anchors

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: check-link-20260430-020000
working-dir: /home/doc/code/docs_all_writer_check_link_20260430_020000
-->
