### PR TITLE
[Digital Human] Fix Timestamp parameter unit from seconds to milliseconds in Digital Human callback docs

### DIFF
--- a/core_products/digital-human/en/server/streaming-apis/receiving-callback.mdx
+++ b/core_products/digital-human/en/server/streaming-apis/receiving-callback.mdx
@@ -27,7 +27,7 @@ Through this callback, you can monitor Digital Human video stream task related i
 | AppId | Number | The unique identifier assigned by ZEGOCLOUD to the developer's app. |
 | EventType | Number | Event notification type.<ul><li>3: Digital Human video stream task status.</li><li>4: Digital Human video stream drive task status.</li></ul> |
 | Nonce | String | Random number, used for signature calculation. |
-| Timestamp | String | Unix timestamp (seconds) when the callback was sent, used for signature calculation. |
+| Timestamp | String | Unix timestamp (milliseconds) when the callback was sent, used for signature calculation. |
 | Signature | String | Signature string, used to verify the callback sender's identity. |
 | EventTime | Number | Unix timestamp (milliseconds) when the event occurred on the ZEGOCLOUD server. |
 | TaskId | String | Digital Human video stream task ID. |

--- a/core_products/digital-human/zh/server/streaming-apis/receiving-callback.mdx
+++ b/core_products/digital-human/zh/server/streaming-apis/receiving-callback.mdx
@@ -27,7 +27,7 @@ import Content from '/snippets/Reuse/SignatureVerificationZH.mdx'
 | AppId | Number | ZEGO 给开发者 APP 的唯一标识。 |
 | EventType | Number | 事件通知类型。<ul><li>3:数字人视频流任务状态。</li><li>4:数字人视频流驱动任务状态。</li></ul> |
 | Nonce | String | 随机数,用于检验串计算。 |
-| Timestamp | String | 回调发送时的 Unix 时间戳(秒),用于检验串计算。 |
+| Timestamp | String | 回调发送时的 Unix 时间戳(毫秒),用于检验串计算。 |
 | Signature | String | 检验串,验证回调发送方身份。 |
 | EventTime | Number | 事件在 ZEGO 服务器上发生的 Unix 时间戳(毫秒)。 |
 | TaskId | String | 数字人视频流任务 ID。 |


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [x] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix Timestamp parameter unit from seconds to milliseconds in Digital Human callback docs

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: fix_timestamp_unit_1778495940
working-dir: /home/doc/code/docs_all_writer_fix_timestamp_unit
-->
