### PR TITLE
[ZIM] Update Signaling plan room join limit to 1 in ZIM Android pricing Plan Differences table

### DIFF
--- a/core_products/zim/en/docs_zim_android/Introduction/Pricing.mdx
+++ b/core_products/zim/en/docs_zim_android/Introduction/Pricing.mdx
@@ -159,7 +159,7 @@ In-app Chat provides plans such as Free, Signaling, Pro, and Enterprise.
 <tr>
 <td>Number of Rooms a User Can Join Simultaneously</td>
 <td>1</td>
-<td>-</td>
+<td>1</td>
 <td>5</td>
 <td>5</td>
 </tr>


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Update Signaling plan room join limit to 1 in ZIM Android pricing Plan Differences table

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: fix_zim_signaling_rooms_1778669610
working-dir: /home/doc/code/docs_all_writer_fix_zim_signaling_rooms
-->
