### PR TITLE
[ZIM] Update mute group example: change custom role from 5 to 101 in manage-groups docs

### DIFF
--- a/core_products/zim/en/docs_zim_android/Guides/Group/Manage groups.mdx
+++ b/core_products/zim/en/docs_zim_android/Guides/Group/Manage groups.mdx
@@ -1756,9 +1756,9 @@ ZIMGroupMuteConfig config = new ZIMGroupMuteConfig();
 config.mode = ZIMGroupMuteMode.Custom;
 // These members are muted for 30 seconds.
 config.duration = 30;
-// Group members whose `role` value is `3` or `5` are muted.
+// Group members whose `role` value is `3` or `101` are muted.
 config.roles.add(3);
-config.roles.add(5);
+config.roles.add(101);
 
 
 // Enable muting
@@ -1784,8 +1784,8 @@ try {
     config.mode = ZIMGroupMuteMode.custom;
     // Set the mute duration to 30 seconds
     config.duration = 30;
-    // Mute group members with roles 3 and 5
-    config.roles = [3,5];
+    // Mute group members with roles 3 and 101
+    config.roles = [3,101];
     // Enable mute
     bool isMute = true;
     ZIMGroupMutedResult result = await ZIM.getInstance()!.muteGroup(isMute, 'group_id', config);
@@ -1825,7 +1825,7 @@ const zim::ZIMError &errorInfo) {
 const config: ZIMGroupMuteConfig = {
     mode: 3, //Group members of specified roles are muted.
     duration: 30, //hese members are muted for 30 seconds.
-    roles:[3, 5],//Group members whose `role` value is `3` or `5` are muted.
+    roles:[3, 101],//Group members whose `role` value is `3` or `101` are muted.
 };
 
 // Enable muting
@@ -1849,8 +1849,8 @@ ZIMGroupMuteConfig *muteConfig = [[ZIMGroupMuteConfig alloc] init];
 muteConfig.mode = ZIMGroupMuteModeCustom;
 // These members are muted for 30 seconds.
 muteConfig.duration = 30;
-// Group members whose `role` value is `3` or `5` are muted.
-muteConfig.roles = @[@3,@5];
+// Group members whose `role` value is `3` or `101` are muted.
+muteConfig.roles = @[@3,@101];
 
 [[ZIM getInstance] muteGroup:YES groupID:@"groupID" config:muteConfig callback:^(NSString * _Nonnull groupID, BOOL isMute, ZIMGroupMuteInfo * _Nonnull info, ZIMError * _Nonnull errorInfo) {
     // You can obtain the group muting information in the `info` field.

--- a/core_products/zim/zh/docs_zim_android_zh/Guides/Group/Manage groups.mdx
+++ b/core_products/zim/zh/docs_zim_android_zh/Guides/Group/Manage groups.mdx
@@ -1899,9 +1899,9 @@ ZIMGroupMuteConfig config = new ZIMGroupMuteConfig();
 config.mode = ZIMGroupMuteMode.Custom;
 // 禁言时长为 30 秒
 config.duration = 30;
-// 角色为 3 和 5 的群成员被禁言
+// 角色为 3 和 101 的群成员被禁言
 config.roles.add(3);
-config.roles.add(5);
+config.roles.add(101);
 
 // 开启禁言
 boolean isMute = true;
@@ -1925,8 +1925,8 @@ try {
     config.mode = ZIMGroupMuteMode.custom;
     // 禁言时长为 30 秒
     config.duration = 30;
-    // 角色为 3 和 5 的群成员被禁言
-    config.roles = [3,5];
+    // 角色为 3 和 101 的群成员被禁言
+    config.roles = [3,101];
     // 开启禁言
     bool isMute = true;
     ZIMGroupMutedResult result = await ZIM.getInstance()!.muteGroup(isMute, 'group_id', config);
@@ -1966,7 +1966,7 @@ zim_->muteGroup(is_mute, group_id, config,
 const config: ZIMGroupMuteConfig = {
     mode: 3, //群组禁言模式为指定角色的群成员不能发言
     duration: 30, //禁言时长为 30 秒
-    roles:[3, 5],//角色为 3 和 5 的群成员被禁言
+    roles:[3, 101],//角色为 3 和 101 的群成员被禁言
 };
 
 // 开启禁言
@@ -1990,8 +1990,8 @@ ZIMGroupMuteConfig *muteConfig = [[ZIMGroupMuteConfig alloc] init];
 muteConfig.mode = ZIMGroupMuteModeCustom;
 // 禁言时长为 30 秒
 muteConfig.duration = 30;
-// 角色为 3 和 5 的群成员被禁言
-muteConfig.roles = @[@3,@5];
+// 角色为 3 和 101 的群成员被禁言
+muteConfig.roles = @[@3,@101];
 
 [[ZIM getInstance] muteGroup:YES groupID:@"groupID" config:muteConfig callback:^(NSString * _Nonnull groupID, BOOL isMute, ZIMGroupMuteInfo * _Nonnull info, ZIMError * _Nonnull errorInfo) {
     // 开发者可从 info 中获取到群组禁言信息


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Update mute group example: change custom role from 5 to 101 in manage-groups docs

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: workspace-writer
working-dir: /home/doc/code/docs_all_writer_mute_roles_update
-->
