### PR TITLE
[AIAgent] Remove group_id from MiniMax TTS example in configuring-tts

### DIFF
--- a/core_products/aiagent/en/server/guides/configuring-tts.mdx
+++ b/core_products/aiagent/en/server/guides/configuring-tts.mdx
@@ -293,7 +293,6 @@ Some common parameters of voice_setting:
   "Vendor": "Minimax",//Required
   "Params": {//Required
     "app": {//Required
-      //"group_id": "xxxx",
       "api_key": "zego_test"//Required
     },
     "model": "speech-02-turbo-preview",//Required

--- a/core_products/aiagent/zh/server/guides/configuring-tts.mdx
+++ b/core_products/aiagent/zh/server/guides/configuring-tts.mdx
@@ -291,7 +291,6 @@ voice_setting 部分常用参数:
   "Vendor": "Minimax",//必填
   "Params": {//必填
     "app": {//必填
-      //"group_id": "xxxx",
       "api_key": "zego_test"//必填
     },
     "model": "speech-02-turbo-preview",//必填


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [x] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Remove group_id from MiniMax TTS example in configuring-tts

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: workspace-writer
working-dir: /home/doc/code/docs_all_writer_remove_group_id
-->
