### PR TITLE
🚩 Change a part of android class defines from public to private

### DIFF
--- a/core_products/zim/zh/docs_zim_android_zh/Client SDKs/api-reference/struct.mdx
+++ b/core_products/zim/zh/docs_zim_android_zh/Client SDKs/api-reference/struct.mdx
@@ -1,6 +1,6 @@
 ---
 docType: API
-date: "2026-05-22"
+date: "2026-06-10"
 ---
 
 # Struct
@@ -245,7 +245,7 @@ ZIM 应用配置，包含 AppID 和 AppSign。
 </ParamField>
 <ParamField
   name="type"
-  prototype="public [ZIMUserType](./enum#zimusertype) type"
+  prototype="public [ZIMUserInfoType](./enum#zimuserinfotype) type"
   parent_name="ZIMUserInfo"
   parent_type="class">
 用户类型。该字段用于标识当前属于何种子类。
@@ -489,7 +489,7 @@ querySubscribedUserStatusList 查询订阅列表接口的配置项。
 ### 属性
 <ParamField
   name="duration"
-  prototype="public long duration"
+  prototype="private long duration"
   parent_name="ZIMUserCustomStatusUpdateConfig"
   parent_type="class">
 用户自定义状态持续时间。
@@ -745,7 +745,7 @@ userID。
 ### 属性
 <ParamField
   name="increaseCount"
-  prototype="public int increaseCount"
+  prototype="private int increaseCount"
   parent_name="ZIMMessageReactionAddConfig"
   parent_type="class">
 详情描述：当该值传入大于 0 的值时，表示允许同一个用户对同一个表态类型进行多次表态，并会把多次表态时的计数值进行相加。
@@ -858,14 +858,14 @@ userID。
 ### 属性
 <ParamField
   name="reactionType"
-  prototype="public String reactionType"
+  prototype="private String reactionType"
   parent_name="ZIMMessageReactionSimpleInfo"
   parent_type="class">
 详情描述：表态类型，由您定义，长度上限为 32 字节。
 </ParamField>
 <ParamField
   name="sumCount"
-  prototype="public int sumCount"
+  prototype="private int sumCount"
   parent_name="ZIMMessageReactionSimpleInfo"
   parent_type="class">
 详情描述：表态的合计计数
@@ -884,14 +884,14 @@ userID。
 ### 属性
 <ParamField
   name="userID"
-  prototype="public String userID"
+  prototype="private String userID"
   parent_name="ZIMMessageReactionUserFullInfo"
   parent_type="class">
 详情描述：用户 ID
 </ParamField>
 <ParamField
   name="reactions"
-  prototype="public ArrayList<[ZIMMessageReactionSimpleInfo](./struct#zimmessagereactionsimpleinfo)> reactions"
+  prototype="private ArrayList<[ZIMMessageReactionSimpleInfo](./struct#zimmessagereactionsimpleinfo)> reactions"
   parent_name="ZIMMessageReactionUserFullInfo"
   parent_type="class">
 详情描述：当前用户在此条消息下的表态简要信息列表
@@ -910,28 +910,28 @@ userID。
 ### 属性
 <ParamField
   name="userID"
-  prototype="public String userID"
+  prototype="private String userID"
   parent_name="ZIMMessageReactionUserChangeInfo"
   parent_type="class">
 详情描述：当前执行表态操作的用户 ID。
 </ParamField>
 <ParamField
   name="reactionType"
-  prototype="public String reactionType"
+  prototype="private String reactionType"
   parent_name="ZIMMessageReactionUserChangeInfo"
   parent_type="class">
 详情描述：当前变更的表态类型。
 </ParamField>
 <ParamField
   name="action"
-  prototype="public [ZIMMessageReactionUserChangeAction](./enum#zimmessagereactionuserchangeaction) action"
+  prototype="private [ZIMMessageReactionUserChangeAction](./enum#zimmessagereactionuserchangeaction) action"
   parent_name="ZIMMessageReactionUserChangeInfo"
   parent_type="class">
 详情描述：当前用户的表态操作行为
 </ParamField>
 <ParamField
   name="sumCount"
-  prototype="public int sumCount"
+  prototype="private int sumCount"
   parent_name="ZIMMessageReactionUserChangeInfo"
   parent_type="class">
 详情描述：当前表态类型的合计数值。
@@ -1286,196 +1286,196 @@ userID。
 ### 属性
 <ParamField
   name="type"
-  prototype="public [ZIMMessageType](./enum#zimmessagetype) type"
+  prototype="private [ZIMMessageType](./enum#zimmessagetype) type"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息类型。
 </ParamField>
 <ParamField
   name="messageID"
-  prototype="public long messageID"
+  prototype="private long messageID"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：标识这条消息的唯一 ID。业务场景：可用于索引其他消息。注意事项：开发者主动创建一条消息时，不需要修改这个参数，此参数仅在回调时有值。
 </ParamField>
 <ParamField
   name="localMessageID"
-  prototype="public long localMessageID"
+  prototype="private long localMessageID"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：SDK 本地生成的 MessageID,开发者无需关注。
 </ParamField>
 <ParamField
   name="messageSeq"
-  prototype="public long messageSeq"
+  prototype="private long messageSeq"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息的序列号。
 </ParamField>
 <ParamField
   name="senderUserID"
-  prototype="public String senderUserID"
+  prototype="private String senderUserID"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：展示本条消息发送者的 userID。
 </ParamField>
 <ParamField
   name="conversationID"
-  prototype="public String conversationID"
+  prototype="private String conversationID"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：会话的 ID，相同会话类型下的 ID 是唯一的。
 </ParamField>
 <ParamField
   name="conversationType"
-  prototype="public [ZIMConversationType](./enum#zimconversationtype) conversationType"
+  prototype="private [ZIMConversationType](./enum#zimconversationtype) conversationType"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：该消息所属会话的类型。
 </ParamField>
 <ParamField
   name="direction"
-  prototype="public [ZIMMessageDirection](./enum#zimmessagedirection) direction"
+  prototype="private [ZIMMessageDirection](./enum#zimmessagedirection) direction"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：用于描述消息的方向是发送还是接收。
 </ParamField>
 <ParamField
   name="sentStatus"
-  prototype="public [ZIMMessageSentStatus](./enum#zimmessagesentstatus) sentStatus"
+  prototype="private [ZIMMessageSentStatus](./enum#zimmessagesentstatus) sentStatus"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：描述消息的发送状态。
 </ParamField>
 <ParamField
   name="timestamp"
-  prototype="public long timestamp"
+  prototype="private long timestamp"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：标识一条消息的发送时间。业务场景：用于呈现一条消息的发送时间，并可用于消息排序。注意事项：此为标准 UNIX 时间戳，单位为毫秒。
 </ParamField>
 <ParamField
   name="orderKey"
-  prototype="public long orderKey"
+  prototype="private long orderKey"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：orderKey 越大消息越新，可用于消息排序。
 </ParamField>
 <ParamField
   name="isUserInserted"
-  prototype="public boolean isUserInserted"
+  prototype="private boolean isUserInserted"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：该消息是否是开发者通过 [insertMessageToLocalDB] 接口插入的消息。默认值：false。
 </ParamField>
 <ParamField
   name="receiptStatus"
-  prototype="public [ZIMMessageReceiptStatus](./enum#zimmessagereceiptstatus) receiptStatus"
+  prototype="private [ZIMMessageReceiptStatus](./enum#zimmessagereceiptstatus) receiptStatus"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：描述该消息的回执状态。业务场景：用于在回执消息中，判断当前消息是处于什么状态。
 </ParamField>
 <ParamField
   name="extendedData"
-  prototype="public String extendedData"
+  prototype="private String extendedData"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息拓展字段。业务场景：可为消息附加拓展字段，然后发送给对端。是否必填：否。注意事项：长度为1k，可联系技术支持进行配置。支持版本: 2.6.0 及以上。
 </ParamField>
 <ParamField
   name="localExtendedData"
-  prototype="public String localExtendedData"
+  prototype="private String localExtendedData"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：仅本端可见的消息拓展字段，可附带额外的信息存储到本地，可通过 [updateMessageLocalExtendedData] 修改，目前长度的限制是 128K。如有特殊需求，可联系 ZEGO 技术支持进行配置。
 </ParamField>
 <ParamField
   name="reactions"
-  prototype="public ArrayList<[ZIMMessageReaction](./struct#zimmessagereaction)> reactions"
+  prototype="private ArrayList<[ZIMMessageReaction](./struct#zimmessagereaction)> reactions"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息表态列表，可通过该字段携带如 emoji 表情，投票信息等与用户强相关的数据。
 </ParamField>
 <ParamField
   name="isBroadcastMessage"
-  prototype="public boolean isBroadcastMessage"
+  prototype="private boolean isBroadcastMessage"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：该消息是否是全员推送消息。是否必填：SDK内部赋值。
 </ParamField>
 <ParamField
   name="mentionedUserIDs"
-  prototype="public ArrayList<String> mentionedUserIDs"
+  prototype="private ArrayList<String> mentionedUserIDs"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：提醒一批相关的用户。业务表现可为“@某用户”。业务场景：发消息时可以带上是否必填：否。注意事项：该值并不会在消息文本上增加 @某用户 的字样，需要开发者自行实现。支持版本 : 2.14.0 及以上。
 </ParamField>
 <ParamField
   name="isMentionAll"
-  prototype="public boolean isMentionAll"
+  prototype="private boolean isMentionAll"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：是否需要提醒所有人。业务表现可为“@所有人”。业务场景：例如在群或者房间可使用。是否必填：否。默认值：false。建议值：如果需要提醒所有人，可以设置为 true。注意事项：该值并不会在消息文本上增加 @所有人 的字样，需要开发者自行实现。支持版本 : 2.14.0 及以上。
 </ParamField>
 <ParamField
   name="repliedInfo"
-  prototype="public [ZIMMessageRepliedInfo](./struct#zimmessagerepliedinfo) repliedInfo"
+  prototype="private [ZIMMessageRepliedInfo](./struct#zimmessagerepliedinfo) repliedInfo"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息回复信息。
 </ParamField>
 <ParamField
   name="rootRepliedCount"
-  prototype="public int rootRepliedCount"
+  prototype="private int rootRepliedCount"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息根回复数量。
 </ParamField>
 <ParamField
   name="isServerMessage"
-  prototype="public boolean isServerMessage"
+  prototype="private boolean isServerMessage"
   parent_name="ZIMMessage"
   parent_type="class">
 是否为通过服务端 API 所发送的消息
 </ParamField>
 <ParamField
   name="cbInnerID"
-  prototype="public String cbInnerID"
+  prototype="private String cbInnerID"
   parent_name="ZIMMessage"
   parent_type="class">
 标识这条消息是否为合并消息里的子消息，若该值大于 0，则当条消息对象为通过查询合并消息所得到的子消息
 </ParamField>
 <ParamField
   name="editorUserID"
-  prototype="public String editorUserID"
+  prototype="private String editorUserID"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息编辑者的 userID。
 </ParamField>
 <ParamField
   name="editedTime"
-  prototype="public long editedTime"
+  prototype="private long editedTime"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息编辑时间。
 </ParamField>
 <ParamField
   name="isGroupTargetedMessage"
-  prototype="public boolean isGroupTargetedMessage"
+  prototype="private boolean isGroupTargetedMessage"
   parent_name="ZIMMessage"
   parent_type="class">
 标识该消息是否为群定向消息
 </ParamField>
 <ParamField
   name="pinnedUserID"
-  prototype="public String pinnedUserID"
+  prototype="private String pinnedUserID"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息置顶者的 userID。
 </ParamField>
 <ParamField
   name="pinnedTime"
-  prototype="public long pinnedTime"
+  prototype="private long pinnedTime"
   parent_name="ZIMMessage"
   parent_type="class">
 详情描述：消息编辑时间。
@@ -1494,35 +1494,35 @@ userID。
 ### 属性
 <ParamField
   name="fileLocalPath"
-  prototype="public String fileLocalPath"
+  prototype="private String fileLocalPath"
   parent_name="ZIMMediaMessage"
   parent_type="class">
 详情描述：媒体消息的文件的本地绝对路径。是否必填：如果发送本地文件，则发送端必填，否则消息会发送失败。
 </ParamField>
 <ParamField
   name="fileDownloadUrl"
-  prototype="public String fileDownloadUrl"
+  prototype="private String fileDownloadUrl"
   parent_name="ZIMMediaMessage"
   parent_type="class">
 详情描述：媒体消息的外部下载 URL，用于开发者将媒体文件上传到自己的服务器中时，通过填入该 URL 让 SDK 透传到其他用户中。是否必填：如果发送的是外部 URL，发送端必填。
 </ParamField>
 <ParamField
   name="fileUID"
-  prototype="public String fileUID"
+  prototype="private String fileUID"
   parent_name="ZIMMediaMessage"
   parent_type="class">
 详情描述：媒体文件的唯一 ID。是否必填：发送端不需要填，该值由 SDK 生成。
 </ParamField>
 <ParamField
   name="fileName"
-  prototype="public String fileName"
+  prototype="private String fileName"
   parent_name="ZIMMediaMessage"
   parent_type="class">
 详情描述：媒体文件的文件名。是否必填：如果发送的是外部 URL，则需要填写该值，且需要包含文件扩展名。如果发送的是本地文件，该值选填。
 </ParamField>
 <ParamField
   name="fileSize"
-  prototype="public long fileSize"
+  prototype="private long fileSize"
   parent_name="ZIMMediaMessage"
   parent_type="class">
 详情描述：媒体文件的大小。是否必填：发送端不需要填，该值由 SDK 生成。
@@ -1631,70 +1631,70 @@ userID。
 ### 属性
 <ParamField
   name="thumbnailDownloadUrl"
-  prototype="public String thumbnailDownloadUrl"
+  prototype="private String thumbnailDownloadUrl"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：图片文件的缩略图外部下载 URL。当开发者将缩略图上传到自己的服务器上时，可以通过该字段让 SDK 透传到其他用户中。是否必填：发送端选填，当 fileDownloadUrl 填入后，该字段才生效。
 </ParamField>
 <ParamField
   name="thumbnailLocalPath"
-  prototype="public String thumbnailLocalPath"
+  prototype="private String thumbnailLocalPath"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：图片文件的缩略图本地路径。是否必填：发送端不需要填，当调用 [downloadMediaFile] 下载之后， SDK 会生成该值。
 </ParamField>
 <ParamField
   name="largeImageDownloadUrl"
-  prototype="public String largeImageDownloadUrl"
+  prototype="private String largeImageDownloadUrl"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：图片文件的大图外部下载 URL。当开发者将大图上传到自己的服务器上时，可以通过该字段让 SDK 透传到其他用户中。是否必填：发送端选填，当 fileDownloadUrl 填入后，该字段才生效。
 </ParamField>
 <ParamField
   name="largeImageLocalPath"
-  prototype="public String largeImageLocalPath"
+  prototype="private String largeImageLocalPath"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：图片文件的大图本地路径。是否必填：发送端不需要填，当调用 [downloadMediaFile] 下载之后， SDK 会生成该值。
 </ParamField>
 <ParamField
   name="originalImageWidth"
-  prototype="public int originalImageWidth"
+  prototype="private int originalImageWidth"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：原图宽度。
 </ParamField>
 <ParamField
   name="originalImageHeight"
-  prototype="public int originalImageHeight"
+  prototype="private int originalImageHeight"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：原图高度。
 </ParamField>
 <ParamField
   name="largeImageWidth"
-  prototype="public int largeImageWidth"
+  prototype="private int largeImageWidth"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：大图宽度。
 </ParamField>
 <ParamField
   name="largeImageHeight"
-  prototype="public int largeImageHeight"
+  prototype="private int largeImageHeight"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：大图高度。
 </ParamField>
 <ParamField
   name="thumbnailWidth"
-  prototype="public int thumbnailWidth"
+  prototype="private int thumbnailWidth"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：缩略图宽度。
 </ParamField>
 <ParamField
   name="thumbnailHeight"
-  prototype="public int thumbnailHeight"
+  prototype="private int thumbnailHeight"
   parent_name="ZIMImageMessage"
   parent_type="class">
 详情描述：缩略图高度。
@@ -1724,7 +1724,7 @@ userID。
 ### 属性
 <ParamField
   name="audioDuration"
-  prototype="public long audioDuration"
+  prototype="private long audioDuration"
   parent_name="ZIMAudioMessage"
   parent_type="class">
 详情描述：音频文件的时长。是否必填：发送本地音频消息时，发送端必填，不填会导致音频消息发送失败。
@@ -1743,35 +1743,35 @@ userID。
 ### 属性
 <ParamField
   name="videoDuration"
-  prototype="public long videoDuration"
+  prototype="private long videoDuration"
   parent_name="ZIMVideoMessage"
   parent_type="class">
 详情描述：视频文件的时长。是否必填：发送本地视频时，发送端必填，不填会导致视频消息发送失败。
 </ParamField>
 <ParamField
   name="videoFirstFrameDownloadUrl"
-  prototype="public String videoFirstFrameDownloadUrl"
+  prototype="private String videoFirstFrameDownloadUrl"
   parent_name="ZIMVideoMessage"
   parent_type="class">
 详情描述：视频文件的缩略图外部下载 URL。当开发者将首帧图上传到自己的服务器上时，可以通过该字段让 SDK 透传到其他用户中。是否必填：发送端选填，当 fileDownloadUrl 填入后，该字段才生效。
 </ParamField>
 <ParamField
   name="videoFirstFrameLocalPath"
-  prototype="public String videoFirstFrameLocalPath"
+  prototype="private String videoFirstFrameLocalPath"
   parent_name="ZIMVideoMessage"
   parent_type="class">
 详情描述：视频文件的首帧图本地路径。是否必填：发送端不需要填，当调用 [downloadMediaFile] 下载之后， SDK 会生成该值。
 </ParamField>
 <ParamField
   name="videoFirstFrameWidth"
-  prototype="public int videoFirstFrameWidth"
+  prototype="private int videoFirstFrameWidth"
   parent_name="ZIMVideoMessage"
   parent_type="class">
 详情描述：视频首帧宽度。
 </ParamField>
 <ParamField
   name="videoFirstFrameHeight"
-  prototype="public int videoFirstFrameHeight"
+  prototype="private int videoFirstFrameHeight"
   parent_name="ZIMVideoMessage"
   parent_type="class">
 详情描述：视频首帧高度。
@@ -1790,49 +1790,49 @@ userID。
 ### 属性
 <ParamField
   name="revokeType"
-  prototype="public [ZIMRevokeType](./enum#zimrevoketype) revokeType"
+  prototype="private [ZIMRevokeType](./enum#zimrevoketype) revokeType"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：撤回类型。
 </ParamField>
 <ParamField
   name="revokeTimestamp"
-  prototype="public long revokeTimestamp"
+  prototype="private long revokeTimestamp"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：撤回时间戳。
 </ParamField>
 <ParamField
   name="operatedUserID"
-  prototype="public String operatedUserID"
+  prototype="private String operatedUserID"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：撤回操作者的用户 ID。
 </ParamField>
 <ParamField
   name="originalMessageType"
-  prototype="public [ZIMMessageType](./enum#zimmessagetype) originalMessageType"
+  prototype="private [ZIMMessageType](./enum#zimmessagetype) originalMessageType"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：原始消息类型。
 </ParamField>
 <ParamField
   name="originalTextMessageContent"
-  prototype="public String originalTextMessageContent"
+  prototype="private String originalTextMessageContent"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：原始文本消息内容，若撤回的是非文本消息，则该字段为空。
 </ParamField>
 <ParamField
   name="revokeExtendedData"
-  prototype="public String revokeExtendedData"
+  prototype="private String revokeExtendedData"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：撤回附带的消息。
 </ParamField>
 <ParamField
   name="revokeStatus"
-  prototype="public [ZIMMessageRevokeStatus](./enum#zimmessagerevokestatus) revokeStatus"
+  prototype="private [ZIMMessageRevokeStatus](./enum#zimmessagerevokestatus) revokeStatus"
   parent_name="ZIMRevokeMessage"
   parent_type="class">
 详情描述：撤回状态。
@@ -1927,14 +1927,14 @@ Tips 消息对象。
 ### 属性
 <ParamField
   name="messageInfoList"
-  prototype="public ArrayList<[ZIMMessageLiteInfo](./struct#zimmessageliteinfo)> messageInfoList"
+  prototype="private ArrayList<[ZIMMessageLiteInfo](./struct#zimmessageliteinfo)> messageInfoList"
   parent_name="ZIMMultipleMessage"
   parent_type="class">
 详情描述：组合消息的内容列表。
 </ParamField>
 <ParamField
   name="failedIndexList"
-  prototype="public ArrayList<Integer> failedIndexList"
+  prototype="private ArrayList<Integer> failedIndexList"
   parent_name="ZIMMultipleMessage"
   parent_type="class">
 详情描述：组合消息中失败的索引列表。
@@ -2700,14 +2700,14 @@ Tips 消息群消息置顶状态变化事件附加信息。
 ### 属性
 <ParamField
   name="pinStatus"
-  prototype="public [ZIMMessagePinStatus](./enum#zimmessagepinstatus) pinStatus"
+  prototype="private [ZIMMessagePinStatus](./enum#zimmessagepinstatus) pinStatus"
   parent_name="ZIMMessagePinStatusChangeInfo"
   parent_type="class">
 消息置顶状态
 </ParamField>
 <ParamField
   name="message"
-  prototype="public [ZIMMessage](./struct#zimmessage) message"
+  prototype="private [ZIMMessage](./struct#zimmessage) message"
   parent_name="ZIMMessagePinStatusChangeInfo"
   parent_type="class">
 消息置顶状态变更的消息对象
@@ -2783,14 +2783,14 @@ Tips 消息群消息置顶状态变化事件附加信息。
 ### 属性
 <ParamField
   name="message"
-  prototype="public [ZIMMessage](./struct#zimmessage) message"
+  prototype="private [ZIMMessage](./struct#zimmessage) message"
   parent_name="ZIMMessageReactionChangeInfo"
   parent_type="class">
 详情描述：消息表态信息变更的消息对象，可用于直接替换开发者持有的旧数据。
 </ParamField>
 <ParamField
   name="userChangeInfoList"
-  prototype="public ArrayList<[ZIMMessageReactionUserChangeInfo](./struct#zimmessagereactionuserchangeinfo)> userChangeInfoList"
+  prototype="private ArrayList<[ZIMMessageReactionUserChangeInfo](./struct#zimmessagereactionuserchangeinfo)> userChangeInfoList"
   parent_name="ZIMMessageReactionChangeInfo"
   parent_type="class">
 详情描述：当前消息下的用户表态操作变更的信息列表
@@ -5734,21 +5734,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityID"
-  prototype="public String communityID"
+  prototype="private String communityID"
   parent_name="ZIMCommunityInfo"
   parent_type="class">
 社群 ID。
 </ParamField>
 <ParamField
   name="communityName"
-  prototype="public String communityName"
+  prototype="private String communityName"
   parent_name="ZIMCommunityInfo"
   parent_type="class">
 社群名称。
 </ParamField>
 <ParamField
   name="communityAvatarUrl"
-  prototype="public String communityAvatarUrl"
+  prototype="private String communityAvatarUrl"
   parent_name="ZIMCommunityInfo"
   parent_type="class">
 社群头像 URL。
@@ -5767,14 +5767,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="baseInfo"
-  prototype="public [ZIMCommunityInfo](./struct#zimcommunityinfo) baseInfo"
+  prototype="private [ZIMCommunityInfo](./struct#zimcommunityinfo) baseInfo"
   parent_name="ZIMCommunity"
   parent_type="class">
 社群基础信息。
 </ParamField>
 <ParamField
   name="totalUnreadMessageCount"
-  prototype="public int totalUnreadMessageCount"
+  prototype="private int totalUnreadMessageCount"
   parent_name="ZIMCommunity"
   parent_type="class">
 所有频道的总未读消息数。
@@ -5793,49 +5793,49 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="baseInfo"
-  prototype="public [ZIMCommunityInfo](./struct#zimcommunityinfo) baseInfo"
+  prototype="private [ZIMCommunityInfo](./struct#zimcommunityinfo) baseInfo"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 社群基础信息。
 </ParamField>
 <ParamField
   name="communityNotice"
-  prototype="public String communityNotice"
+  prototype="private String communityNotice"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 社群公告。
 </ParamField>
 <ParamField
   name="communityAttributes"
-  prototype="public HashMap<String, String> communityAttributes"
+  prototype="private HashMap<String, String> communityAttributes"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 社群属性。
 </ParamField>
 <ParamField
   name="createTime"
-  prototype="public long createTime"
+  prototype="private long createTime"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 社群创建时间。
 </ParamField>
 <ParamField
   name="creatorUserID"
-  prototype="public String creatorUserID"
+  prototype="private String creatorUserID"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 社群创建者的用户 ID。
 </ParamField>
 <ParamField
   name="currentMemberCount"
-  prototype="public int currentMemberCount"
+  prototype="private int currentMemberCount"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 当前社群成员数量。
 </ParamField>
 <ParamField
   name="notificationStatus"
-  prototype="public [ZIMCommunityMessageNotificationStatus](./enum#zimcommunitymessagenotificationstatus) notificationStatus"
+  prototype="private [ZIMCommunityMessageNotificationStatus](./enum#zimcommunitymessagenotificationstatus) notificationStatus"
   parent_name="ZIMCommunityFullInfo"
   parent_type="class">
 社群消息通知状态。
@@ -5854,14 +5854,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityNotice"
-  prototype="public String communityNotice"
+  prototype="private String communityNotice"
   parent_name="ZIMCommunityCreateConfig"
   parent_type="class">
 创建社群时设置的社群公告。
 </ParamField>
 <ParamField
   name="communityAttributes"
-  prototype="public HashMap<String, String> communityAttributes"
+  prototype="private HashMap<String, String> communityAttributes"
   parent_name="ZIMCommunityCreateConfig"
   parent_type="class">
 创建社群时设置的社群属性。
@@ -5880,7 +5880,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="nextFlag"
-  prototype="public long nextFlag"
+  prototype="private long nextFlag"
   parent_name="ZIMCommunityListQueryConfig"
   parent_type="class">
 查询下一页的分页标志。
@@ -5899,14 +5899,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="action"
-  prototype="public [ZIMCommunityListChangeAction](./enum#zimcommunitylistchangeaction) action"
+  prototype="private [ZIMCommunityListChangeAction](./enum#zimcommunitylistchangeaction) action"
   parent_name="ZIMCommunityChangeInfo"
   parent_type="class">
 社群列表变更事件
 </ParamField>
 <ParamField
   name="community"
-  prototype="public [ZIMCommunity](./struct#zimcommunity) community"
+  prototype="private [ZIMCommunity](./struct#zimcommunity) community"
   parent_name="ZIMCommunityChangeInfo"
   parent_type="class">
 变更的社群
@@ -5925,21 +5925,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="nextFlag"
-  prototype="public long nextFlag"
+  prototype="private long nextFlag"
   parent_name="ZIMCommunityMemberListQueryConfig"
   parent_type="class">
 分页标记，用于获取下一页列表数据。
 </ParamField>
 <ParamField
   name="channelID"
-  prototype="public String channelID"
+  prototype="private String channelID"
   parent_name="ZIMCommunityMemberListQueryConfig"
   parent_type="class">
 是否指定频道 ID 进行查询
 </ParamField>
 <ParamField
   name="isMutedMember"
-  prototype="public boolean isMutedMember"
+  prototype="private boolean isMutedMember"
   parent_name="ZIMCommunityMemberListQueryConfig"
   parent_type="class">
 是否指定查询被禁言的成员
@@ -5958,7 +5958,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityInfo"
-  prototype="public [ZIMCommunityFullInfo](./struct#zimcommunityfullinfo) communityInfo"
+  prototype="private [ZIMCommunityFullInfo](./struct#zimcommunityfullinfo) communityInfo"
   parent_name="ZIMCommunityFullInfoUpdateInfo"
   parent_type="class">
 变更后的社群详细信息
@@ -5977,21 +5977,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="enterTime"
-  prototype="public long enterTime"
+  prototype="private long enterTime"
   parent_name="ZIMCommunityMemberEnterInfo"
   parent_type="class">
 社群进入时间
 </ParamField>
 <ParamField
   name="enterType"
-  prototype="public [ZIMCommunityMemberEnterType](./enum#zimcommunitymemberentertype) enterType"
+  prototype="private [ZIMCommunityMemberEnterType](./enum#zimcommunitymemberentertype) enterType"
   parent_name="ZIMCommunityMemberEnterInfo"
   parent_type="class">
 社群进入事件类型
 </ParamField>
 <ParamField
   name="operatedUserID"
-  prototype="public String operatedUserID"
+  prototype="private String operatedUserID"
   parent_name="ZIMCommunityMemberEnterInfo"
   parent_type="class">
 社群进入操作者 userID
@@ -6010,21 +6010,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="muteType"
-  prototype="public [ZIMCommunityMemberMuteType](./enum#zimcommunitymembermutetype) muteType"
+  prototype="private [ZIMCommunityMemberMuteType](./enum#zimcommunitymembermutetype) muteType"
   parent_name="ZIMCommunityMemberMuteInfo"
   parent_type="class">
 社群成员禁言类型
 </ParamField>
 <ParamField
   name="channelID"
-  prototype="public String channelID"
+  prototype="private String channelID"
   parent_name="ZIMCommunityMemberMuteInfo"
   parent_type="class">
 禁言所在的频道 ID，为空则为社群层面禁言。
 </ParamField>
 <ParamField
   name="muteExpiredTime"
-  prototype="public long muteExpiredTime"
+  prototype="private long muteExpiredTime"
   parent_name="ZIMCommunityMemberMuteInfo"
   parent_type="class">
 成员禁言的到期时间。
@@ -6043,21 +6043,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="memberRole"
-  prototype="public int memberRole"
+  prototype="private int memberRole"
   parent_name="ZIMCommunityMemberInfo"
   parent_type="class">
 社群成员角色，1 为社群主，2 为管理员，3 为普通成员
 </ParamField>
 <ParamField
   name="enterInfo"
-  prototype="public [ZIMCommunityMemberEnterInfo](./struct#zimcommunitymemberenterinfo) enterInfo"
+  prototype="private [ZIMCommunityMemberEnterInfo](./struct#zimcommunitymemberenterinfo) enterInfo"
   parent_name="ZIMCommunityMemberInfo"
   parent_type="class">
 社群成员进入信息
 </ParamField>
 <ParamField
   name="muteInfo"
-  prototype="public [ZIMCommunityMemberMuteInfo](./struct#zimcommunitymembermuteinfo) muteInfo"
+  prototype="private [ZIMCommunityMemberMuteInfo](./struct#zimcommunitymembermuteinfo) muteInfo"
   parent_name="ZIMCommunityMemberInfo"
   parent_type="class">
 社群成员被禁言信息
@@ -6076,7 +6076,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="memberRole"
-  prototype="public int memberRole"
+  prototype="private int memberRole"
   parent_name="ZIMCommunityMemberSimpleInfo"
   parent_type="class">
 社群成员角色，1 为社群主，2 为管理员，3 为普通成员
@@ -6095,21 +6095,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="state"
-  prototype="public [ZIMCommunityMemberChangeState](./enum#zimcommunitymemberchangestate) state"
+  prototype="private [ZIMCommunityMemberChangeState](./enum#zimcommunitymemberchangestate) state"
   parent_name="ZIMCommunityMemberStateChangeInfo"
   parent_type="class">
 社群成员状态
 </ParamField>
 <ParamField
   name="action"
-  prototype="public [ZIMCommunityMemberChangeAction](./enum#zimcommunitymemberchangeaction) action"
+  prototype="private [ZIMCommunityMemberChangeAction](./enum#zimcommunitymemberchangeaction) action"
   parent_name="ZIMCommunityMemberStateChangeInfo"
   parent_type="class">
 社群成员状态变更事件
 </ParamField>
 <ParamField
   name="memberInfo"
-  prototype="public [ZIMCommunityMemberSimpleInfo](./struct#zimcommunitymembersimpleinfo) memberInfo"
+  prototype="private [ZIMCommunityMemberSimpleInfo](./struct#zimcommunitymembersimpleinfo) memberInfo"
   parent_name="ZIMCommunityMemberStateChangeInfo"
   parent_type="class">
 状态变更的社群成员简要信息
@@ -6128,7 +6128,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="memberInfo"
-  prototype="public [ZIMCommunityMemberInfo](./struct#zimcommunitymemberinfo) memberInfo"
+  prototype="private [ZIMCommunityMemberInfo](./struct#zimcommunitymemberinfo) memberInfo"
   parent_name="ZIMCommunityMemberInfoUpdateInfo"
   parent_type="class">
 社群成员变更信息
@@ -6147,35 +6147,35 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="channelID"
-  prototype="public String channelID"
+  prototype="private String channelID"
   parent_name="ZIMCommunityChannelInfo"
   parent_type="class">
 频道 ID。
 </ParamField>
 <ParamField
   name="channelType"
-  prototype="public [ZIMCommunityChannelType](./enum#zimcommunitychanneltype) channelType"
+  prototype="private [ZIMCommunityChannelType](./enum#zimcommunitychanneltype) channelType"
   parent_name="ZIMCommunityChannelInfo"
   parent_type="class">
 社群频道类型。
 </ParamField>
 <ParamField
   name="channelName"
-  prototype="public String channelName"
+  prototype="private String channelName"
   parent_name="ZIMCommunityChannelInfo"
   parent_type="class">
 频道名称。
 </ParamField>
 <ParamField
   name="channelAvatarUrl"
-  prototype="public String channelAvatarUrl"
+  prototype="private String channelAvatarUrl"
   parent_name="ZIMCommunityChannelInfo"
   parent_type="class">
 频道头像 URL。
 </ParamField>
 <ParamField
   name="communityID"
-  prototype="public String communityID"
+  prototype="private String communityID"
   parent_name="ZIMCommunityChannelInfo"
   parent_type="class">
 频道所属的社群 ID。
@@ -6194,21 +6194,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="mode"
-  prototype="public [ZIMCommunityChannelMuteMode](./enum#zimcommunitychannelmutemode) mode"
+  prototype="private [ZIMCommunityChannelMuteMode](./enum#zimcommunitychannelmutemode) mode"
   parent_name="ZIMCommunityChannelMuteInfo"
   parent_type="class">
 社群频道禁言模式
 </ParamField>
 <ParamField
   name="expiredTime"
-  prototype="public long expiredTime"
+  prototype="private long expiredTime"
   parent_name="ZIMCommunityChannelMuteInfo"
   parent_type="class">
 频道禁言的到期时间。
 </ParamField>
 <ParamField
   name="roles"
-  prototype="public ArrayList<Integer> roles"
+  prototype="private ArrayList<Integer> roles"
   parent_name="ZIMCommunityChannelMuteInfo"
   parent_type="class">
 社群频道中被禁言的角色列表。
@@ -6227,63 +6227,63 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="baseInfo"
-  prototype="public [ZIMCommunityChannelInfo](./struct#zimcommunitychannelinfo) baseInfo"
+  prototype="private [ZIMCommunityChannelInfo](./struct#zimcommunitychannelinfo) baseInfo"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道基础信息。
 </ParamField>
 <ParamField
   name="conversationID"
-  prototype="public String conversationID"
+  prototype="private String conversationID"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道的会话 ID。
 </ParamField>
 <ParamField
   name="channelAttributes"
-  prototype="public HashMap<String, String> channelAttributes"
+  prototype="private HashMap<String, String> channelAttributes"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道属性。
 </ParamField>
 <ParamField
   name="notificationStatus"
-  prototype="public [ZIMConversationNotificationStatus](./enum#zimconversationnotificationstatus) notificationStatus"
+  prototype="private [ZIMConversationNotificationStatus](./enum#zimconversationnotificationstatus) notificationStatus"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道的消息通知状态。
 </ParamField>
 <ParamField
   name="unreadMessageCount"
-  prototype="public int unreadMessageCount"
+  prototype="private int unreadMessageCount"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道的未读消息数量。
 </ParamField>
 <ParamField
   name="lastMessage"
-  prototype="public [ZIMMessage](./struct#zimmessage) lastMessage"
+  prototype="private [ZIMMessage](./struct#zimmessage) lastMessage"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道中的最后一条消息。
 </ParamField>
 <ParamField
   name="mentionedInfoList"
-  prototype="public ArrayList<[ZIMMessageMentionedInfo](./struct#zimmessagementionedinfo)> mentionedInfoList"
+  prototype="private ArrayList<[ZIMMessageMentionedInfo](./struct#zimmessagementionedinfo)> mentionedInfoList"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道中的 @ 信息列表。
 </ParamField>
 <ParamField
   name="selfMutedExpiredTime"
-  prototype="public long selfMutedExpiredTime"
+  prototype="private long selfMutedExpiredTime"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 本端用户在该频道的禁言到期时间。
 </ParamField>
 <ParamField
   name="draft"
-  prototype="public String draft"
+  prototype="private String draft"
   parent_name="ZIMCommunityChannel"
   parent_type="class">
 社群频道的草稿消息。
@@ -6302,49 +6302,49 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="baseInfo"
-  prototype="public [ZIMCommunityChannelInfo](./struct#zimcommunitychannelinfo) baseInfo"
+  prototype="private [ZIMCommunityChannelInfo](./struct#zimcommunitychannelinfo) baseInfo"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 频道基础信息。
 </ParamField>
 <ParamField
   name="createTime"
-  prototype="public long createTime"
+  prototype="private long createTime"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 频道创建时间。
 </ParamField>
 <ParamField
   name="creatorUserID"
-  prototype="public String creatorUserID"
+  prototype="private String creatorUserID"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 频道创建者的用户 ID。
 </ParamField>
 <ParamField
   name="channelNotice"
-  prototype="public String channelNotice"
+  prototype="private String channelNotice"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 频道公告。
 </ParamField>
 <ParamField
   name="channelAttributes"
-  prototype="public HashMap<String, String> channelAttributes"
+  prototype="private HashMap<String, String> channelAttributes"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 频道属性。
 </ParamField>
 <ParamField
   name="currentMemberCount"
-  prototype="public int currentMemberCount"
+  prototype="private int currentMemberCount"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 当前频道成员数量。
 </ParamField>
 <ParamField
   name="muteInfo"
-  prototype="public [ZIMCommunityChannelMuteInfo](./struct#zimcommunitychannelmuteinfo) muteInfo"
+  prototype="private [ZIMCommunityChannelMuteInfo](./struct#zimcommunitychannelmuteinfo) muteInfo"
   parent_name="ZIMCommunityChannelFullInfo"
   parent_type="class">
 社群频道的禁言信息。
@@ -6363,14 +6363,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="channelNotice"
-  prototype="public String channelNotice"
+  prototype="private String channelNotice"
   parent_name="ZIMCommunityChannelCreateConfig"
   parent_type="class">
 创建频道时设置的频道公告。
 </ParamField>
 <ParamField
   name="channelAttributes"
-  prototype="public HashMap<String, String> channelAttributes"
+  prototype="private HashMap<String, String> channelAttributes"
   parent_name="ZIMCommunityChannelCreateConfig"
   parent_type="class">
 创建频道时设置的频道属性。
@@ -6389,7 +6389,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="nextFlag"
-  prototype="public long nextFlag"
+  prototype="private long nextFlag"
   parent_name="ZIMCommunityChannelListQueryConfig"
   parent_type="class">
 查询下一页的分页标志。
@@ -6408,14 +6408,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="action"
-  prototype="public [ZIMCommunityChannelListChangeAction](./enum#zimcommunitychannellistchangeaction) action"
+  prototype="private [ZIMCommunityChannelListChangeAction](./enum#zimcommunitychannellistchangeaction) action"
   parent_name="ZIMCommunityChannelChangeInfo"
   parent_type="class">
 频道列表变更的动作类型。
 </ParamField>
 <ParamField
   name="channel"
-  prototype="public [ZIMCommunityChannel](./struct#zimcommunitychannel) channel"
+  prototype="private [ZIMCommunityChannel](./struct#zimcommunitychannel) channel"
   parent_name="ZIMCommunityChannelChangeInfo"
   parent_type="class">
 发生变更的社群频道信息。
@@ -6434,7 +6434,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="channelInfo"
-  prototype="public [ZIMCommunityChannelFullInfo](./struct#zimcommunitychannelfullinfo) channelInfo"
+  prototype="private [ZIMCommunityChannelFullInfo](./struct#zimcommunitychannelfullinfo) channelInfo"
   parent_name="ZIMCommunityChannelFullInfoUpdateInfo"
   parent_type="class">
 变更后的社群频道详细信息
@@ -6453,21 +6453,21 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="mode"
-  prototype="public [ZIMCommunityChannelMuteMode](./enum#zimcommunitychannelmutemode) mode"
+  prototype="private [ZIMCommunityChannelMuteMode](./enum#zimcommunitychannelmutemode) mode"
   parent_name="ZIMCommunityChannelMuteConfig"
   parent_type="class">
 社群频道禁言模式
 </ParamField>
 <ParamField
   name="roles"
-  prototype="public ArrayList<Integer> roles"
+  prototype="private ArrayList<Integer> roles"
   parent_name="ZIMCommunityChannelMuteConfig"
   parent_type="class">
 要禁言的角色列表，为空则禁言所有角色。
 </ParamField>
 <ParamField
   name="duration"
-  prototype="public int duration"
+  prototype="private int duration"
   parent_name="ZIMCommunityChannelMuteConfig"
   parent_type="class">
 禁言时长（秒），0 表示解除禁言。
@@ -6486,14 +6486,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="duration"
-  prototype="public int duration"
+  prototype="private int duration"
   parent_name="ZIMCommunityMemberMuteConfig"
   parent_type="class">
 禁言时长（秒），0 表示解除禁言。
 </ParamField>
 <ParamField
   name="channelID"
-  prototype="public String channelID"
+  prototype="private String channelID"
   parent_name="ZIMCommunityMemberMuteConfig"
   parent_type="class">
 频道 ID，为空则在社群层面禁言。
@@ -6508,14 +6508,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="reactions"
-  prototype="public ArrayList<[ZIMMessageReaction](./struct#zimmessagereaction)> reactions"
+  prototype="private ArrayList<[ZIMMessageReaction](./struct#zimmessagereaction)> reactions"
   parent_name="ZIMMessageReactionsChangedEventResult"
   parent_type="class">
 消息表态变更信息列表
 </ParamField>
 <ParamField
   name="changeInfoList"
-  prototype="public ArrayList<[ZIMMessageReactionChangeInfo](./struct#zimmessagereactionchangeinfo)> changeInfoList"
+  prototype="private ArrayList<[ZIMMessageReactionChangeInfo](./struct#zimmessagereactionchangeinfo)> changeInfoList"
   parent_name="ZIMMessageReactionsChangedEventResult"
   parent_type="class">
 消息表态变更信息列表
@@ -6530,14 +6530,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="messageList"
-  prototype="public ArrayList<[ZIMMessage](./struct#zimmessage)> messageList"
+  prototype="private ArrayList<[ZIMMessage](./struct#zimmessage)> messageList"
   parent_name="ZIMMessageReceivedEventResult"
   parent_type="class">
 消息列表
 </ParamField>
 <ParamField
   name="receivedInfo"
-  prototype="public [ZIMMessageReceivedInfo](./struct#zimmessagereceivedinfo) receivedInfo"
+  prototype="private [ZIMMessageReceivedInfo](./struct#zimmessagereceivedinfo) receivedInfo"
   parent_name="ZIMMessageReceivedEventResult"
   parent_type="class">
 消息接收信息
@@ -6552,7 +6552,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="changeInfoList"
-  prototype="public ArrayList<[ZIMCommunityChangeInfo](./struct#zimcommunitychangeinfo)> changeInfoList"
+  prototype="private ArrayList<[ZIMCommunityChangeInfo](./struct#zimcommunitychangeinfo)> changeInfoList"
   parent_name="ZIMCommunityListChangedEventResult"
   parent_type="class">
 社群变更信息列表
@@ -6567,7 +6567,7 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="updateInfoList"
-  prototype="public ArrayList<[ZIMCommunityFullInfoUpdateInfo](./struct#zimcommunityfullinfoupdateinfo)> updateInfoList"
+  prototype="private ArrayList<[ZIMCommunityFullInfoUpdateInfo](./struct#zimcommunityfullinfoupdateinfo)> updateInfoList"
   parent_name="ZIMCommunityInfoUpdatedEventResult"
   parent_type="class">
 社群详情信息变更列表
@@ -6582,14 +6582,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityID"
-  prototype="public String communityID"
+  prototype="private String communityID"
   parent_name="ZIMCommunityMemberStateChangedEventResult"
   parent_type="class">
 社群 ID。
 </ParamField>
 <ParamField
   name="changeInfoList"
-  prototype="public ArrayList<[ZIMCommunityMemberStateChangeInfo](./struct#zimcommunitymemberstatechangeinfo)> changeInfoList"
+  prototype="private ArrayList<[ZIMCommunityMemberStateChangeInfo](./struct#zimcommunitymemberstatechangeinfo)> changeInfoList"
   parent_name="ZIMCommunityMemberStateChangedEventResult"
   parent_type="class">
 社群成员状态变更列表
@@ -6604,14 +6604,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityID"
-  prototype="public String communityID"
+  prototype="private String communityID"
   parent_name="ZIMCommunityMemberInfoUpdatedEventResult"
   parent_type="class">
 社群 ID。
 </ParamField>
 <ParamField
   name="updateInfoList"
-  prototype="public ArrayList<[ZIMCommunityMemberInfoUpdateInfo](./struct#zimcommunitymemberinfoupdateinfo)> updateInfoList"
+  prototype="private ArrayList<[ZIMCommunityMemberInfoUpdateInfo](./struct#zimcommunitymemberinfoupdateinfo)> updateInfoList"
   parent_name="ZIMCommunityMemberInfoUpdatedEventResult"
   parent_type="class">
 社群成员信息变更列表
@@ -6626,14 +6626,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityID"
-  prototype="public String communityID"
+  prototype="private String communityID"
   parent_name="ZIMCommunityChannelListChangedEventResult"
   parent_type="class">
 社群 ID。
 </ParamField>
 <ParamField
   name="changeInfoList"
-  prototype="public ArrayList<[ZIMCommunityChannelChangeInfo](./struct#zimcommunitychannelchangeinfo)> changeInfoList"
+  prototype="private ArrayList<[ZIMCommunityChannelChangeInfo](./struct#zimcommunitychannelchangeinfo)> changeInfoList"
   parent_name="ZIMCommunityChannelListChangedEventResult"
   parent_type="class">
 社群频道变更信息列表
@@ -6648,14 +6648,14 @@ conversationName,与会话对应的 groupName/userName 值相同。
 ### 属性
 <ParamField
   name="communityID"
-  prototype="public String communityID"
+  prototype="private String communityID"
   parent_name="ZIMCommunityChannelInfoUpdatedEventResult"
   parent_type="class">
 社群 ID。
 </ParamField>
 <ParamField
   name="updateInfoList"
-  prototype="public ArrayList<[ZIMCommunityChannelFullInfoUpdateInfo](./struct#zimcommunitychannelfullinfoupdateinfo)> updateInfoList"
+  prototype="private ArrayList<[ZIMCommunityChannelFullInfoUpdateInfo](./struct#zimcommunitychannelfullinfoupdateinfo)> updateInfoList"
   parent_name="ZIMCommunityChannelInfoUpdatedEventResult"
   parent_type="class">
 社群频道详情信息变更列表


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General(控制台/政策与协议/词汇表)
- [ ] FAQ(常见问题)
- [ ] 其他

## 变更描述

<!-- 请简要描述本次变更的内容和原因 -->
将部分 android class 的属性作用于从 public 改为 private，与 SDK 本身暴露的作用域一致。


## 相关 Issue

<!-- 选填，例如: #1234 -->
