### PR TITLE
[RTC] Add DetectFrequency value range (0,60] to start-censor-video API

### DIFF
--- a/core_products/real-time-voice-video/en/server/api-reference/moderation/start-censor-video.yaml
+++ b/core_products/real-time-voice-video/en/server/api-reference/moderation/start-censor-video.yaml
@@ -279,6 +279,7 @@ components:
               description: |
                 Frame capture frequency.
                 Unit: seconds. Default is 3s, capture one frame for moderation.
+                Value range: (0,60].
               example: 5
             ResultCallbackUrl:
               type: string

--- a/core_products/real-time-voice-video/zh/server/api-reference/moderation/start-censor-video.yaml
+++ b/core_products/real-time-voice-video/zh/server/api-reference/moderation/start-censor-video.yaml
@@ -276,6 +276,7 @@ components:
               description: |
                 截帧频率。
                 单位：秒。默认为 3s 截帧一次进行审核。
+                取值范围：(0,60]。
               example: 5
             ResultCallbackUrl:
               type: string


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Add DetectFrequency value range (0,60] to start-censor-video API

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: docs_all_writer_detect_freq_range
working-dir: /home/doc/code/docs_all_writer_detect_freq_range
-->
