### PR TITLE
[RTC] Remove console note from callback configuration section in receiving-callback docs (EN only)

### DIFF
--- a/core_products/real-time-voice-video/en/server/callback/receiving-callback.mdx
+++ b/core_products/real-time-voice-video/en/server/callback/receiving-callback.mdx
@@ -49,17 +49,6 @@ Developers can configure Callback information in the [ZEGO Console ](https://con
 
 At the same time, you can configure the URL address to receive ZEGO callbacks as needed.
 
-<Note title="Note">
-
-
-You can view the console interface as follows:
-
-- Users who registered for the [ZEGOCLOUD Console](https://console.zegocloud.com) after **2021-11-16**, please refer to [Console - Server Callback Configuration](/console/server-callback-configuration).
-- Users who registered for the [ZEGOCLOUD Console](https://console.zegocloud.com) on or before **2021-11-16**, please refer to "Advanced Configuration" in [Console (Old Version) - Project Management](/console-old/project-management#高级配置).
-
-
-</Note>
-
 ## Callback description
 
 - Request method: POST.


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Remove console note from callback configuration section in receiving-callback docs (EN only)

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: oc_82eb13982574d7e175c4940204eeaf06
working-dir: /home/doc/code/docs_all_writer_rtc_callback_remove_note
-->
