### PR TITLE
[AIAgent] Fix incorrect method name destroyLocalStream to destroyStream in Web quick-start docs

### DIFF
--- a/core_products/aiagent/en/android/quick-start-with-digital-human.mdx
+++ b/core_products/aiagent/en/android/quick-start-with-digital-human.mdx
@@ -1335,7 +1335,7 @@ async function stopCall() {
   }
 }
 stopCall();
-zg.destroyLocalStream(localStream);
+zg.destroyStream(localStream);
 zg.logoutRoom();
 ```
 :::

--- a/core_products/aiagent/en/android/quick-start.mdx
+++ b/core_products/aiagent/en/android/quick-start.mdx
@@ -1134,7 +1134,7 @@ async function stopCall() {
   }
 }
 stopCall();
-zg.destroyLocalStream(localStream);
+zg.destroyStream(localStream);
 zg.logoutRoom();
 ```
 :::

--- a/core_products/aiagent/zh/android/quick-start-with-digital-human.mdx
+++ b/core_products/aiagent/zh/android/quick-start-with-digital-human.mdx
@@ -1337,7 +1337,7 @@ async function stopCall() {
   }
 }
 stopCall();
-zg.destroyLocalStream(localStream);
+zg.destroyStream(localStream);
 zg.logoutRoom();
 ```
 :::

--- a/core_products/aiagent/zh/android/quick-start.mdx
+++ b/core_products/aiagent/zh/android/quick-start.mdx
@@ -1103,7 +1103,7 @@ async function stopCall() {
   }
 }
 stopCall();
-zg.destroyLocalStream(localStream);
+zg.destroyStream(localStream);
 zg.logoutRoom();
 ```
 :::


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [x] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix incorrect method name destroyLocalStream to destroyStream in Web quick-start docs

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: 
working-dir: /home/doc/code/docs_all_writer_fix_destroyLocalStream
-->
