### PR TITLE
[ZIM] Fix ZIM Audio integrate SDK id in Android sidebar

### DIFF
--- a/core_products/zim/zh/docs_zim_android_zh/sidebars.json
+++ b/core_products/zim/zh/docs_zim_android_zh/sidebars.json
@@ -652,7 +652,7 @@
         {
           "type": "doc",
           "label": "集成 SDK",
-          "id": "zim-audio/integrate-the-sdk"
+          "id": "zim-audio/integrate-the-zim-audio-sdk"
         },
         {
           "type": "doc",


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix ZIM Audio integrate SDK id in Android sidebar

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: zego-Precision-3650-Tower_1782964763
working-dir: /home/doc/code/docs_all_writer_zim_sidebar_fix
-->
