### PR TITLE
[FAQ] Update Token auth description: SDK verifies AppSign first when both passed

### DIFF
--- a/general/en/faq/express-token-upgrade.mdx
+++ b/general/en/faq/express-token-upgrade.mdx
@@ -70,7 +70,7 @@ To improve the security of your project, for developers using AppSign authentica
   </tr>
   <tr>
     <td>Token Authentication<b> (Recommended)</b></td>
-    <td>Token authentication means passing AppSign as empty or not passing it when creating the engine, and you must pass Token when logging into a room. After authentication passes, you can use real-time audio and video functionality. <br />This method is compatible with AppSign authentication. That is, when you pass both AppSign and Token, the SDK will pass both parameters to the ZEGO server. The parameters passed need to be verified through, otherwise the authentication will not pass.<br /></td>
+    <td>Token authentication means passing AppSign as empty or not passing it when creating the engine, and you must pass Token when logging into a room. After authentication passes, you can use real-time audio and video functionality. <br />This method is compatible with AppSign authentication. When you pass both AppSign and Token, the SDK will verify AppSign first. Please ensure AppSign is correct.<br /></td>
     <td>High security level.<br />Reason: Token is issued by the developer's self-built server and authenticated on the client side, and the issued Token has a time limit. Therefore, we recommend you use Token authentication.</td>
   </tr>
   <tr>

--- a/general/zh/faq/express-token-upgrade.mdx
+++ b/general/zh/faq/express-token-upgrade.mdx
@@ -60,7 +60,7 @@ import ArticleMetadata from './ArticleMetadata';
   </tr>
   <tr>
     <td>Token 鉴权<b>（推荐）</b></td>
-    <td>Token 鉴权是在创建引擎时将 AppSign <b>传空或不传</b>，并且在登录房间时必须传入 Token，鉴权通过后即可使用实时音视频功能。 <br />该方式能兼容 Appsign 鉴权，即当您同时传入了 AppSign 和 Token 时，SDK 会把这两个参数都传给 ZEGO 服务端。传递的参数都需要校验通过，否则鉴权不能通过。<br /></td>
+    <td>Token 鉴权是在创建引擎时将 AppSign <b>传空或不传</b>，并且在登录房间时必须传入 Token，鉴权通过后即可使用实时音视频功能。 <br />该方式能兼容 Appsign 鉴权。当您同时传入了 AppSign 和 Token 时，SDK 会优先校验 Appsign，请确保 Appsign 无误。<br /></td>
     <td>安全级别高。<br />原因为：通过开发者自建服务端下发 Token，并且在客户端上进行认证，且下发的 Token 具有时效性。因此，我们推荐您使用 Token 鉴权。</td>
   </tr>
   <tr>


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [x] FAQ (常见问题)
- [ ] 其他

## 变更描述

Update Token auth description: SDK verifies AppSign first when both passed

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: 987f2dab-74b1-40ff-bf30-87e0ea321c7e
working-dir: /home/doc/code/docs_all_writer_faq_token_upgrade
-->
