### PR TITLE
[ZIM] ZIM 3.1.0: merge sender/receiver descriptions, fix ZIM message reference, move deprecated APIs to upgrade guide

### DIFF
--- a/core_products/zim/en/docs_zim_android/Client SDKs/ZIM upgrade guide.mdx
+++ b/core_products/zim/en/docs_zim_android/Client SDKs/ZIM upgrade guide.mdx
@@ -1173,6 +1173,23 @@ Starting from version 3.0.0, when setting room member attributes via [setRoomMem
 
 - - -
 
+## 3.1.0 Upgrade Guide
+
+<Warning title="Warning">
+
+ZIM SDK 3.1.0 has added deprecation markers to some APIs. Please refer to the following instructions for migration.
+</Warning>
+
+### Newly deprecated APIs (recommended to migrate)
+
+#### Message receipt query APIs
+
+`queryGroupMessageReceiptReadMemberList` and `queryGroupMessageReceiptUnreadMemberList` have been marked as deprecated in this version. They are still functional but it is recommended to migrate to [queryGroupMessageReceiptMemberList](@queryGroupMessageReceiptMemberList).
+
+This API can query the list of members who have read, have not read (not delivered), or have been delivered for a group message in a single call, replacing the above two deprecated APIs.
+
+- - -
+
 ## 2.28.0 Upgrade Guide
 
 <Warning title="Warning">

--- a/core_products/zim/en/docs_zim_android/Guides/Messaging/Read receipts.mdx
+++ b/core_products/zim/en/docs_zim_android/Guides/Messaging/Read receipts.mdx
@@ -257,6 +257,28 @@ To query the list of members who have not read a group message, call the {getPla
 - To perform operations on the historical messages of the conversation, you need to get the historical messages and determine the receipt status of the historical messages. For details, see [Get message history](./Get%20message%20history.mdx).
 </Warning>
 
+### Get the delivered status of receipt messages
+
+Starting from ZIM 3.1.0, a "Delivered" status has been added between "Processing" and "Completed" for message receipts. After the sender sends a receipt message, if the receiver's device has received the message, the receipt status will change to "Delivered". This feature is disabled by default. You can contact technical support to enable it.
+Developers can listen for receipt status changes through the [onMessageReceiptChanged](@onMessageReceiptChanged) callback.
+
+**1-on-1 chat:**
+
+- When the receiver receives a message online, the SDK automatically confirms delivery. When the receiver receives an offline push, the delivery can be confirmed through the server API. When there is no offline push, the SDK automatically confirms delivery after the receiver comes online and pulls the message.
+- After the receiver confirms delivery, the sender receives the [onMessageReceiptChanged](@onMessageReceiptChanged) callback, and the message receipt status changes from "Processing" to "Delivered".
+
+**Group chat:**
+
+- When all group members have received the message and some members have not yet read it, the sender's message receipt status transitions to "Delivered".
+
+<Warning title="Note">
+
+Receiving an offline push does not mean the message itself has been delivered. The ZIM message object must actually reach the receiver or be confirmed through the server API before the status transitions to "Delivered".
+
+</Warning>
+
+If you need the message receipt status to change to "Delivered" on the sender's side after the receiver receives an offline push (iOS can enable push interception, Android FCM can use DataMessage push type, domestic Android vendors do not support this for now), you can call the server API [GroupDeliveryReceipt](https://zim-api.zego.im/?Action=GroupDeliveryReceipt) to confirm after receiving the push.
+
 ## Sample code
 
 :::if{props.platform=undefined}

--- a/core_products/zim/zh/docs_zim_android_zh/Client SDKs/ZIM upgrade guide.mdx
+++ b/core_products/zim/zh/docs_zim_android_zh/Client SDKs/ZIM upgrade guide.mdx
@@ -1166,6 +1166,23 @@ ZIMGroupMessageNotificationStatus status = ZIMGroupMessageNotificationStatus.DIS
 
 - - -
 
+## 3.1.0 升级指南
+
+<Warning title="注意">
+
+ZIM SDK 3.1.0 版本新增了部分接口废弃标记，请参考以下说明完成迁移。
+</Warning>
+
+### 新增废弃接口（建议迁移）
+
+#### 消息回执查询接口
+
+`queryGroupMessageReceiptReadMemberList` 和 `queryGroupMessageReceiptUnreadMemberList` 回调在本版本中新增废弃标记，当前仍可正常使用，但建议尽快迁移至 [queryGroupMessageReceiptMemberList](@queryGroupMessageReceiptMemberList)。
+
+该接口可一次性查询群消息的已读、未读（未送达）、或已送达状态的成员列表，替代上述两个废弃接口。
+
+- - -
+
 ## 2.28.0 升级指南
 
 <Warning title="注意">

--- a/core_products/zim/zh/docs_zim_android_zh/Guides/Messaging/Read receipts.mdx
+++ b/core_products/zim/zh/docs_zim_android_zh/Guides/Messaging/Read receipts.mdx
@@ -861,27 +861,20 @@ zim.queryGroupMessageReceiptUnreadMemberList(groupMsgObj, groupMsgObj.conversati
 
 **单聊场景：**
 
-- **发送端**：接收端在线收到消息后，SDK 自动确认已送达；或接收端收到离线推送后调用服务端 API 确认已送达。发送端收到 [onMessageReceiptChanged](@onMessageReceiptChanged) 回调，消息回执状态由"回执中"变更为"已送达"。
-- **接收端**：在线收到消息时，SDK 自动确认已送达；收到离线推送时，调用服务端 API 确认已送达；无离线推送时，本端上线拉取到消息后 SDK 自动确认已送达。以上场景均会收到 [onMessageReceiptChanged](@onMessageReceiptChanged) 回调，状态变更为"已送达"。
+- 接收端在线收到消息时，SDK 自动确认已送达；接收端收到离线推送时，可通过服务端 API 确认已送达；接收端无离线推送时，本端上线拉取到消息后 SDK 自动确认已送达。
+- 发送端在接收端确认已送达后，收到 [onMessageReceiptChanged](@onMessageReceiptChanged) 回调，消息回执状态由"回执中"变更为"已送达"。
 
 **群聊场景：**
 
-- **发送端**：当所有群成员都已送达且仍有成员未读时，消息回执状态流转为"已送达"。
+- 当所有群成员都已送达且仍有成员未读时，发送端的消息回执状态流转为"已送达"。
 
 <Warning title="注意">
 
-离线推送送达不代表消息本身送达，必须 ZIM message 实际送达到接收端或通过服务端 API 确认，才会流转为"已送达"。
+离线推送送达不代表消息本身送达，必须 ZIM 消息对象实际送达到接收端或通过服务端 API 确认，才会流转为"已送达"。
 
 </Warning>
 
 如果您需要在消息接收方收到离线推送后使得消息回执状态在发送端变更为"已送达"（iOS 可通过开启推送拦截，Android FCM 可通过使用 DataMessage 推送消息类型的方式，国内 Android 厂商暂不支持），可在收到推送后调用服务端 API [GroupDeliveryReceipt](https://zim-api.zego.im/?Action=GroupDeliveryReceipt) 进行确认。
-
-### 废弃接口
-
-- [queryGroupMessageReceiptReadMemberList](@queryGroupMessageReceiptReadMemberList)
-- [queryGroupMessageReceiptUnreadMemberList](@queryGroupMessageReceiptUnreadMemberList)
-
-上述接口请使用新接口 [queryGroupMessageReceiptMemberList](@queryGroupMessageReceiptMemberList) 替换。
 
 ### 新增接口：queryGroupMessageReceiptMemberList
 


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

ZIM 3.1.0: merge sender/receiver descriptions, fix ZIM message reference, move deprecated APIs to upgrade guide

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: 984be6e8-22f4-40f3-a62d-4d039da0a73f
working-dir: /home/doc/code/docs_all_writer_zim310_receipts_deprecated
-->
