### PR TITLE
docs(aiagent/zh): 更新智能体中文文档，修正回调章节命名并补充相关内容

### DIFF
--- a/core_products/aiagent/zh/android/quick-start-with-digital-human.mdx
+++ b/core_products/aiagent/zh/android/quick-start-with-digital-human.mdx
@@ -1548,10 +1548,10 @@ async function checkSystemRequirements() {
 </div>
 :::
 
-## 监听异常回调
+## 监听回调
 
-<Warning title="注意">由于 LLM 和 TTS 等参数比较多且复杂，在接入测试过程中容易因为参数配置错误导致的智能体不回答或者不说话等各种异常问题。我们强烈建议您在接入测试过程中监听异常回调，并根据回调信息快速排查问题。</Warning>
+<Warning title="注意">由于 LLM 和 TTS 等参数比较多且复杂，在接入测试过程中容易因为参数配置错误导致的智能体不回答或者不说话等各种异常问题。我们强烈建议您在接入测试过程中监听回调，并根据回调信息快速排查问题。</Warning>
 
 <Card title="接收回调" href="/aiagent-server/callbacks/receiving-callback" target="_blank">
-点击查看监听异常回调指引。监听回调中 Event 为 Exception 的事件。通过 Data.Code 和 Data.Message 可以快速定位问题。
+点击查看监听回调指引。监听回调中 Event 为 Exception 的事件。通过 Data.Code 和 Data.Message 可以快速定位问题。
 </Card>

--- a/core_products/aiagent/zh/android/quick-start-with-live-digital-human.mdx
+++ b/core_products/aiagent/zh/android/quick-start-with-live-digital-human.mdx
@@ -1006,7 +1006,7 @@ async function logoutRoom() {
 
 RTC 和 CDN 模式都使用 `agent_instance_id` 调用主动 TTS 和停止实例接口。CDN 模式不需要客户端登录 RTC 房间，也不需要集成数字人 SDK。
 
-## 监听异常回调
+## 监听回调
 
 请监听 Express SDK 的房间登录、拉流状态和错误回调，并在业务后台记录 `agent_instance_id`、`agent_stream_id`、`request_id` 和错误信息，便于定位创建实例、拉流或 TTS 失败原因。
 

--- a/core_products/aiagent/zh/android/quick-start.mdx
+++ b/core_products/aiagent/zh/android/quick-start.mdx
@@ -1340,10 +1340,10 @@ const checkSystemRequirements = async () => {
 ```
 :::
 
-## 监听异常回调
+## 监听回调
 
-<Warning title="注意">由于 LLM 和 TTS 等参数比较多且复杂，在接入测试过程中容易因为参数配置错误导致的智能体不回答或者不说话等各种异常问题。我们强烈建议您在接入测试过程中监听异常回调，并根据回调信息快速排查问题。</Warning>
+<Warning title="注意">由于 LLM 和 TTS 等参数比较多且复杂，在接入测试过程中容易因为参数配置错误导致的智能体不回答或者不说话等各种异常问题。我们强烈建议您在接入测试过程中监听回调，并根据回调信息快速排查问题。</Warning>
 
 <Card title="接收回调" href="/aiagent-server/callbacks/receiving-callback" target="_blank">
-点击查看监听异常回调指引。监听回调中 Event 为 Exception 的事件。通过 Data.Code 和 Data.Message 可以快速定位问题。
+点击查看监听回调指引。监听回调中 Event 为 Exception 的事件。通过 Data.Code 和 Data.Message 可以快速定位问题。
 </Card>

--- a/core_products/aiagent/zh/server/quick-start.mdx
+++ b/core_products/aiagent/zh/server/quick-start.mdx
@@ -372,7 +372,8 @@ async createLiveDigitalHumanAgentInstance(agentId: string, rtcInfo: RtcInfo, dig
     const action = 'CreateLiveDigitalHumanAgentInstance';
     const body = {
         AgentId: agentId,
-        RTC: rtcInfo,
+        RTC: rtcInfo, //二选一
+        CDN: cdnInfo, //如果两个都设置，以 CDN 为准
         DigitalHuman: digitalHuman, // 测试时可使用公共 ID ：c4b56d5c-db98-4d91-86d4-5a97b507da97
     };
     // sendRequest 方法封装了请求的 URL 和公共参数。详情参考：https://doc-zh.zego.im/aiagent-server/api-reference/accessing-server-apis
@@ -419,6 +420,14 @@ Content-Type: application/json
 ```
 
 </Step>
+
+<Step title="展示用户与智能体状态">
+
+如需查看用户与智能体状态，请参考 [展示用户与智能体状态](http://localhost:3000/aiagent-server/guides/display-user-and-agent-status)。
+
+</Step>
+
+
 :::
 <Step title="集成客户端 SDK">
 
@@ -505,10 +514,10 @@ async deleteAgentInstance(agentInstanceId: string) {
 以上就是您实现与智能体进行实时语音互动的完整核心流程。
 :::
 
-## 监听异常回调
+## 监听回调
 
-<Warning title="注意">由于 LLM 和 TTS 等参数比较多且复杂，在接入测试过程中容易因为参数配置错误导致的智能体不回答或者不说话等各种异常问题。我们强烈建议您在接入测试过程中监听异常回调，并根据回调信息快速排查问题。</Warning>
+<Warning title="注意">由于 LLM 和 TTS 等参数比较多且复杂，在接入测试过程中容易因为参数配置错误导致的智能体不回答或者不说话等各种异常问题。我们强烈建议您在接入测试过程中监听回调，并根据回调信息快速排查问题。</Warning>
 
 <Card title="接收回调" href="/aiagent-server/callbacks/receiving-callback" target="_blank">
-点击查看监听异常回调指引。监听回调中 Event 为 Exception 的事件。通过 Data.Code 和 Data.Message 可以快速定位问题。
+点击查看监听回调指引。监听回调中 Event 为 Exception 的事件。通过 Data.Code 和 Data.Message 可以快速定位问题。
 </Card>


### PR DESCRIPTION
调整多处文档的回调相关章节命名，将「监听异常回调」改为「监听回调」。为服务端快速入门文档新增CDN参数配置注释，并添加查看用户与智能体状态的指引步骤。

## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [x] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General(控制台/政策与协议/词汇表)
- [ ] FAQ(常见问题)
- [ ] 其他

## 变更描述

<!-- 请简要描述本次变更的内容和原因 -->



## 相关 Issue

<!-- 选填，例如: #1234 -->
