### PR TITLE
[RTC] Fix Mini Program SDK filename from ZegoExpressWebRTC to ZegoExpressMiniProgram

### DIFF
--- a/core_products/real-time-voice-video/zh/mini-program/quick-start/we-chat/integrating-sdk.mdx
+++ b/core_products/real-time-voice-video/zh/mini-program/quick-start/we-chat/integrating-sdk.mdx
@@ -39,7 +39,7 @@ date: "2024-05-06"
 
 1. 请参考 [下载](/real-time-video-miniprogram/client-sdk/download-sdk) 文档，下载最新版本的 `微信小程序` SDK。
 
-2. 解压 SDK 压缩包，将 “ZegoExpressWebRTC-x.x.x.js” 文件拷贝到项目中。
+2. 解压 SDK 压缩包，将 “ZegoExpressMiniProgram-x.x.x.js” 文件拷贝到项目中。
 
 3. 在使用到的插件的 JS 文件的最前方导入 SDK。
 


### PR DESCRIPTION
## 涉及产品

- [x] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

Fix Mini Program SDK filename from ZegoExpressWebRTC to ZegoExpressMiniProgram

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: 94287ffa-a7e1-4d5a-a9bd-138c0debe8a3
working-dir: /home/doc/code/docs_all
-->
