### PR TITLE
[Digital Human] DigitalHuman: Add dual-channel audio support for streaming APIs

### DIFF
--- a/core_products/digital-human/en/server/quick-start/interactive-chat-with-ai.mdx
+++ b/core_products/digital-human/en/server/quick-start/interactive-chat-with-ai.mdx
@@ -200,7 +200,7 @@ The core of AI interactive conversation is sending the TTS-synthesized PCM audio
 
 1. Call `DriveByWsStream` to get WebSocket drive info (DriveId and WssAddress)
 2. Establish a WebSocket connection
-3. Send a `Start` command (specifying DriveId and sample rate)
+3. Send a `Start` command (specifying DriveId, sample rate, and channel configuration)
 4. Send TTS-generated PCM audio data frame by frame
 5. Send a `Stop` command
 6. Disconnect the WebSocket connection
@@ -224,9 +224,12 @@ export const callTTSAndDriveDigitalHumanByWebSocket = async (taskId) => {
   // Step 3: Send Start command (usually started before TTS begins)
   ws.send(JSON.stringify({
     Action: "Start",
+    SequenceID: "seq_xxx",
     Payload: {
       DriveId: driveId,
       SampleRate: 24000, // Sample rate must match your actual audio data
+      // Channel: 1, // Audio channel count, 1=mono (default), 2=dual-channel
+      // VoiceChannel: 0, // Voice channel position, 0=mixed (default), 1=left channel, 2=right channel (only effective when Channel is 2)
     },
   }));
 
@@ -248,6 +251,17 @@ export const callTTSAndDriveDigitalHumanByWebSocket = async (taskId) => {
   ws.close();
 };
 ```
+
+### Dual-Channel Audio Description
+
+When transmitting dual-channel audio where the voice is only in one of the channels, you can specify the channel configuration using the following parameters in the `Start` command:
+
+- `Channel`: Audio input channel count. Default value `1` (mono). Set to `2` when transmitting dual-channel audio.
+- `VoiceChannel`: Voice channel position. Default value `0` (mixed). Options: `1` (left channel), `2` (right channel). Only effective when `Channel` is `2`.
+
+<Note title="Note">
+When `Channel` is `2`, audio frame data must be in standard PCM dual-channel interleaved format, with a recommended sample rate of 16000Hz or higher.
+</Note>
 
 ### Implement Client
 

--- a/core_products/digital-human/en/server/streaming-apis/digital-human-streaming/drive-by-audio.mdx
+++ b/core_products/digital-human/en/server/streaming-apis/digital-human-streaming/drive-by-audio.mdx
@@ -22,6 +22,7 @@ The following request parameter list only includes API request parameters and so
 | TaskId      | String | Yes    | Digital Human video stream task ID. Obtained from the response parameter of the [Create Digital Human Video Stream Task](./create-digital-human-stream-task.mdx) API.    |
 | AudioUrl      | String | Yes    | Audio URL link. Supports MP3 and WAV files.    |
 | InterruptMode | Number | No    | Whether to interrupt the currently executing broadcast task and immediately execute this task. Options:<ul><li>0 (default): No, queue and wait for the previous task to complete before executing.</li><li>1: Yes, immediately interrupt the current task and execute this task.</li></ul> |
+| VoiceChannel | Number | No    | The channel where the voice is located. When the input audio is a dual-channel audio file and the voice is only in one of the channels, use this parameter to specify which channel contains the voice, and the system will automatically extract the voice from that channel to drive the Digital Human. Default value: 0. Options:<ul><li>0: Mixed (voice mixed in both left and right channels)</li><li>1: Left channel</li><li>2: Right channel</li></ul> |
 
 ## Request Example
 

--- a/core_products/digital-human/en/server/streaming-apis/digital-human-streaming/drive-by-ws-stream.mdx
+++ b/core_products/digital-human/en/server/streaming-apis/digital-human-streaming/drive-by-ws-stream.mdx
@@ -9,6 +9,8 @@ date: '2026-03-26'
 
 Through this API, you can obtain a WebSocket connection URL. By transmitting PCM audio data to this URL, you can drive the Digital Human to speak in real-time. The WebSocket drive method allows flexible integration with third-party TTS providers to drive the Digital Human. If you have already integrated a third-party TTS provider or have a preferred provider, this method is recommended.
 
+This API supports transmitting both mono-channel and dual-channel PCM audio data. When transmitting dual-channel audio, you can specify the audio channel count via the `Channel` parameter in the WebSocket Start command, and specify the voice channel position via the `VoiceChannel` parameter. The system will automatically extract the voice from the corresponding channel to drive the Digital Human.
+
 For the complete process of driving the Digital Human via WebSocket, please refer to [Implement Interactive Chat with AI Digital Human](/aigc-digital-human-server/quick-start/interactive-chat-with-ai).
 
 <Note title="Note">

--- a/core_products/digital-human/zh/server/quick-start/interactive-chat-with-ai.mdx
+++ b/core_products/digital-human/zh/server/quick-start/interactive-chat-with-ai.mdx
@@ -200,7 +200,7 @@ AI 互动对话的核心在于将 TTS 合成的 PCM 音频流通过 WebSocket �
 
 1. 调用 `DriveByWsStream` 获取 WebSocket 驱动信息（DriveId 和 WssAddress）
 2. 建立 WebSocket 连接
-3. 发送 `Start` 指令（指定 DriveId 和采样率）
+3. 发送 `Start` 指令（指定 DriveId、采样率和声道配置）
 4. 将 TTS 产生的 PCM 音频数据逐帧发送
 5. 发送 `Stop` 指令
 6. 断开 WebSocket 连接
@@ -224,9 +224,12 @@ export const callTTSAndDriveDigitalHumanByWebSocket = async (taskId) => {
   // 步骤 3: 发送 Start 指令（通常在 TTS 开启前启动）
   ws.send(JSON.stringify({
     Action: "Start",
+    SequenceID: "seq_xxx",
     Payload: {
       DriveId: driveId,
       SampleRate: 24000, // 采样率需与你实际的音频数据相同
+      // Channel: 1, // 音频声道数，1=单声道（默认），2=双声道
+      // VoiceChannel: 0, // 人声所在声道，0=混流（默认），1=左声道，2=右声道（仅在 Channel 为 2 时生效）
     },
   }));
 
@@ -248,6 +251,17 @@ export const callTTSAndDriveDigitalHumanByWebSocket = async (taskId) => {
   ws.close();
 };
 ```
+
+### 双声道音频说明
+
+当传入双声道音频且人声仅位于其中一个声道时，可通过 `Start` 指令中的以下参数指定声道配置：
+
+- `Channel`：音频输入声道数。默认值 `1`（单声道），传入双声道音频时设置为 `2`。
+- `VoiceChannel`：人声所在声道位置。默认值 `0`（混流），可选值：`1`（左声道）、`2`（右声道）。仅在 `Channel` 为 `2` 时生效。
+
+<Note title="注意">
+当 `Channel` 为 `2` 时，音频帧数据需为标准的 PCM 双声道交错格式，采样率建议 16000Hz 或更高。
+</Note>
 
 ### 实现客户端
 

--- a/core_products/digital-human/zh/server/streaming-apis/digital-human-streaming/drive-by-audio.mdx
+++ b/core_products/digital-human/zh/server/streaming-apis/digital-human-streaming/drive-by-audio.mdx
@@ -22,6 +22,7 @@ import PostPrototype from '/snippets/common/zh/server/post-prototype.mdx'
 | TaskId      | String | 是    | 数字人视频流任务 ID。 通过 [创建数字人视频流任务](./create-digital-human-stream-task.mdx) 接口的响应参数获取。    |
 | AudioUrl      | String | 是    | 音频 URL 链接，支持 MP3 和 WAV 文件。    |
 | InterruptMode | Number | 否    | 是否打断正在执行的播报任务并立即执行本任务。可选值：<ul><li>0（默认）：否，排队等待前一个任务完成后再执行。</li><li>1：是，立即中断当前任务执行本任务。</li></ul> |
+| VoiceChannel | Number | 否    | 人声所在声道位置。当传入的音频为双声道音频，且人声仅位于其中一个声道时，通过该参数指定人声所在声道，系统将自动从对应声道提取人声进行驱动。默认值：0。可选值：<ul><li>0：混流（人声混合于左右声道）</li><li>1：左声道</li><li>2：右声道</li></ul> |
 
 ## 请求示例
 

--- a/core_products/digital-human/zh/server/streaming-apis/digital-human-streaming/drive-by-ws-stream.mdx
+++ b/core_products/digital-human/zh/server/streaming-apis/digital-human-streaming/drive-by-ws-stream.mdx
@@ -9,6 +9,8 @@ date: '2026-03-26'
 
 通过本接口，您可以获取一个 WebSocket 链接地址。通过向这个地址传输 PCM 音频数据以实时驱动数字人说话。通过 WebSocket 驱动方式可以实现灵活调用第三方 TTS 厂商驱动数字人。如果您已经接入了第三方 TTS 厂商，或者有比较倾向的厂商，推荐您使用此方案驱动数字人。
 
+本接口支持传入单声道和双声道 PCM 音频数据。当传入双声道音频时，可在 WebSocket Start 指令中通过 `Channel` 参数指定音频声道数，并通过 `VoiceChannel` 参数指定人声所在声道位置，系统将自动从对应声道提取人声进行驱动。
+
 如需了解使用 WebSocket 驱动数字人的完整流程，请参考 [实现数字人 AI 互动对话](/aigc-digital-human-server/quick-start/interactive-chat-with-ai)。
 
 <Note title="说明">


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [ ] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [x] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

DigitalHuman: Add dual-channel audio support for streaming APIs

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: 70362458-3963-479a-9bac-c5e0c7886bf6
working-dir: /home/doc/code/docs_all_writer_digital_human_audio_channel
-->
