### PR TITLE
[ZIM] ZIM: Remove virtual gifting from ZIMCommandMessage scenario description

### DIFF
--- a/core_products/zim/en/snippets/MessageTypeEn.mdx
+++ b/core_products/zim/en/snippets/MessageTypeEn.mdx
@@ -13,7 +13,7 @@ import {sendMessageMap, replyMessageMap} from "/snippets/zim/const-linkEN.mdx"
 <td>The signaling message whose content can be customized. A signaling message cannot exceed 5 KB in size, and up to 10 signaling messages can be sent per second per client.</td>
 <td>
 <b>Frequency limit: The sending frequency limit for a single client is 30 times per second (with an interval of 34 milliseconds between two times).</b>
-<p>Signaling messages, unable to be stored, are applicable to signaling transmission (for example, co-hosting, virtual gifting, and course materials sending) in scenarios with a higher concurrency, such as chat rooms and online classrooms.</p><p>Higher concurrency is supported, but it's unreliable: it does not ensure message delivery and order.</p>
+<p>Signaling messages, unable to be stored, are applicable to signaling transmission (for example, co-hosting and course materials sending) in scenarios with a higher concurrency, such as chat rooms and online classrooms.</p><p>Higher concurrency is supported, but it's unreliable: it does not ensure message delivery and order.</p>
 API: {getPlatformData2(props, sendMessageMap)}
 </td>
 </tr>

--- a/core_products/zim/zh/snippets/MessageType.mdx
+++ b/core_products/zim/zh/snippets/MessageType.mdx
@@ -14,7 +14,7 @@ import { replyMessageMap, sendMessageMap } from "/snippets/zim/const-link.mdx"
 <td>开发者可自定义数据内容的信令消息。消息大小不超过 5 KB。</td>
 <td>
 <b>限频：单个客户端发送频率限制为 30 次/秒（两次之间间隔 34 毫秒）。</b>
-<p>不可存储，一般适用于“语聊房”、“在线课堂”等房间内的信令传输，比如上下麦操作、送礼物，发送在线课堂课件等。</p>
+<p>不可存储，一般适用于“语聊房”、“在线课堂”等房间内的信令传输，比如上下麦操作、发送在线课堂课件等。</p>
 <p>支持更高的并发，但不可靠，不保证消息送达和消息顺序。</p>
 
 相关接口：{getPlatformData2(props, sendMessageMap)}


### PR DESCRIPTION
## 涉及产品

- [ ] RTC (实时音视频/实时语音/超低延迟直播)
- [x] ZIM (即时通讯)
- [ ] AIAgent (AI 智能体)
- [ ] Digital Human (数字人)
- [ ] UIKit (CallKit/LiveStreamingKit/LiveAudioRoomKit/VideoConferenceKit)
- [ ] Extension Service (超级白板/云端播放器/云端实时 ASR/云端录制/AI美颜/本地服务端录制/星图)
- [ ] Solution
- [ ] General (控制台/政策与协议/词汇表)
- [ ] FAQ (常见问题)
- [ ] 其他

## 变更描述

ZIM: Remove virtual gifting from ZIMCommandMessage scenario description

## 相关 Issue

无

<!-- metadata
agent-id: writer
session-id: ea2c2ec6-de12-4648-8dda-b8c25f17d602
working-dir: /home/doc/code/docs_all_writer_zim_cmd_msg_fix
-->
